### PR TITLE
Add Diff.compare shorthand

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/Diff.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/Diff.scala
@@ -21,6 +21,8 @@ object Diff extends DiffInstances {
   def apply[T: Diff]: Diff[T] = implicitly[Diff[T]]
 
   def identical[T]: Diff[T] = (left: T, _: T, _: List[FieldPath]) => Identical(left)
+  
+  def compare[T: Diff](left: T, right: T): DiffResult = apply[T].apply(left, right)
 
   // Implicit instance of Diff[T] created from implicit Derived[Diff[T]]
   implicit def anyDiff[T](implicit dd: Derived[Diff[T]]): Diff[T] = dd.value


### PR DESCRIPTION
Are you open to adding some shorthand syntax?

Could be nice to have `Diff.compare` as shorthand for `Diff.apply` followed by another `apply`.
It should also provide nicer type inference: `Diff[Foo].apply(foo1, foo2)` vs `Diff.compare(foo1, foo2)`.

Or maybe add a similar `diff` method to the package object?