### PR TITLE
Improve output of set and map output.

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
@@ -1,35 +1,42 @@
 package com.softwaremill.diffx
 import acyclic.skipped
+import DiffResult._
 
 trait DiffResult {
   def isIdentical: Boolean
 
-  def show: String = showIndented(5)
+  def show: String = showIndented(indentLevel)
 
   private[diffx] def showIndented(indent: Int): String
 }
 
+object DiffResult {
+  private[diffx] final val indentLevel = 5
+}
+
 case class DiffResultObject(name: String, fields: Map[String, DiffResult]) extends DiffResultDifferent {
   override private[diffx] def showIndented(indent: Int): String = {
-    val showFields = fields.map(f => s"${i(indent)}${f._1}: ${f._2.showIndented(indent + 5)}")
+    val showFields = fields.map(f => s"${i(indent)}${f._1}: ${f._2.showIndented(indent + indentLevel)}")
     s"""$name(
-       |${showFields.mkString("\n")})""".stripMargin
+       |${showFields.mkString(",\n")})""".stripMargin
   }
 }
 
 case class DiffResultMap(fields: Map[DiffResult, DiffResult]) extends DiffResultDifferent {
   override private[diffx] def showIndented(indent: Int): String = {
-    val showFields = fields.map(f => s"${i(indent)}${f._1.showIndented(indent + 5)}: ${f._2.showIndented(indent + 5)}")
+    val showFields =
+      fields.map(f =>
+        s"${i(indent)}${f._1.showIndented(indent + indentLevel)}: ${f._2.showIndented(indent + indentLevel)}"
+      )
     s"""Map(
-       |${showFields.mkString("\n")})""".stripMargin
+       |${showFields.mkString(",\n")})""".stripMargin
   }
 }
 
 case class DiffResultSet(diffs: List[DiffResult]) extends DiffResultDifferent {
   override private[diffx] def showIndented(indent: Int): String = {
-    val showFields = diffs.map(f => s"${i(indent)}$f")
-    s"""Set(
-       |${showFields.mkString("\n")})""".stripMargin
+    val showFields = diffs.map(f => s"${i(indent)}${f.showIndented(indent + indentLevel)}")
+    showFields.mkString("Set(\n", ",\n", ")")
   }
 }
 

--- a/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
@@ -1,0 +1,63 @@
+package com.softwaremill.diffx
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport {
+  "diff set output" - {
+    "it should show a simple difference" in {
+      val output = DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).show
+      output shouldBe
+        s"""Set(
+          |     a,
+          |     ${red("1")} -> ${green("2")})""".stripMargin
+    }
+
+    "it should show an indented difference" in {
+      val output = DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).showIndented(5)
+      output shouldBe
+        s"""Set(
+           |     a,
+           |     ${red("1")} -> ${green("2")})""".stripMargin
+    }
+
+    "it should show a nested list difference" in {
+      val output = DiffResultSet(List(Identical("a"), DiffResultSet(List(Identical("b"))))).show
+      output shouldBe
+        s"""Set(
+           |     a,
+           |     Set(
+           |          b))""".stripMargin
+    }
+  }
+
+  "diff map output" - {
+    "it should show a simple diff" in {
+      val output =
+        DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3))).show
+      output shouldBe
+        s"""Map(
+           |     a: ${red("1")} -> ${green("2")},
+           |     ${red("b")}: ${red("3")})""".stripMargin
+    }
+
+    "it should show an indented diff" in {
+      val output =
+        DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3)))
+          .showIndented(5)
+      output shouldBe
+        s"""Map(
+           |     a: ${red("1")} -> ${green("2")},
+           |     ${red("b")}: ${red("3")})""".stripMargin
+    }
+
+    "it should show a nested diff" in {
+      val output =
+        DiffResultMap(Map(Identical("a") -> DiffResultMap(Map(Identical("b") -> DiffResultValue(1, 2))))).show
+      output shouldBe
+        s"""Map(
+           |     a: Map(
+           |          b: ${red("1")} -> ${green("2")}))""".stripMargin
+    }
+  }
+}


### PR DESCRIPTION
Hi, great project. I noticed some issues when working on some json instances over at https://github.com/stephennancekivell/scalatest-json.

* DiffResultSet was calling toString instead of the nested show's
* DiffResultSet wasnt indented
* DiffResultSet, DiffResultMap and DiffResultObject should probably have a comma between values.
