### PR TITLE
Add Refined module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,17 @@ lazy val cats: Project = (project in file("cats"))
   )
   .dependsOn(core)
 
+lazy val refined: Project = (project in file("refined"))
+  .settings(commonSettings: _*)
+  .settings(
+    name := "diffx-refined",
+    libraryDependencies ++= Seq(
+      "eu.timepit" %% "refined" % "0.9.13",
+      scalatestDependency % "test"
+    )
+  )
+  .dependsOn(core)
+
 lazy val rootProject = (project in file("."))
   .settings(commonSettings: _*)
   .settings(publishArtifact := false, name := "diffx")
@@ -86,5 +97,6 @@ lazy val rootProject = (project in file("."))
     scalatest,
     specs2,
     tagging,
-    cats
+    cats,
+    refined
   )

--- a/refined/src/main/scala/com/softwaremill/diffx/refined/RefinedSupport.scala
+++ b/refined/src/main/scala/com/softwaremill/diffx/refined/RefinedSupport.scala
@@ -1,0 +1,8 @@
+package com.softwaremill.diffx.refined
+
+import com.softwaremill.diffx.{Derived, Diff}
+import eu.timepit.refined.api.Refined
+
+trait RefinedSupport {
+  implicit def refinedDiff[T: Diff, P]: Derived[Diff[T Refined P]] = Derived(Diff[T].contramap[T Refined P](_.value))
+}

--- a/refined/src/main/scala/com/softwaremill/diffx/refined/package.scala
+++ b/refined/src/main/scala/com/softwaremill/diffx/refined/package.scala
@@ -1,0 +1,3 @@
+package com.softwaremill.diffx
+
+package object refined extends RefinedSupport {}

--- a/refined/src/test/scala/com/softwaremill/diffx/refined/RefinedSupportTest.scala
+++ b/refined/src/test/scala/com/softwaremill/diffx/refined/RefinedSupportTest.scala
@@ -1,0 +1,23 @@
+package com.softwaremill.diffx.refined
+
+import com.softwaremill.diffx.{Diff, DiffResultObject, DiffResultString, DiffResultValue, Identical}
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RefinedSupportTest extends AnyFlatSpec with Matchers {
+  it should "work for refined types" in {
+    val testData1 = TestData(1, "foo")
+    val testData2 = TestData(1, "bar")
+    compare(testData1, testData2) shouldBe DiffResultObject(
+      "TestData",
+      Map("posInt" -> Identical(1), "nonEmptyString" -> DiffResultString(List(DiffResultValue("foo", "bar"))))
+    )
+  }
+
+  private def compare[T](t1: T, t2: T)(implicit d: Diff[T]) = d.apply(t1, t2)
+}
+
+case class TestData(posInt: PosInt, nonEmptyString: NonEmptyString)


### PR DESCRIPTION
Since Magnolia 0.12.1, autoderivation for Refined values doesn't work at all - see [gitter thread](https://gitter.im/softwaremill/diffx?at=5e6756e98011bb652a0420d5). Previously it would fall back to the basic equality check. With this, you get a diff for the underlying value. 