### PR TITLE
Display diff results as a part of match error in scalatest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The library is published for Scala 2.12 and 2.13.
 
 ## Table of contents
 - [goals of the project](#goals-of-the-project)
+- [colors](#colors)
 - integrations
   - [scalatest](#scalatest-integration)
   - [specs2](#specs2-integration)
@@ -30,6 +31,18 @@ The library is published for Scala 2.12 and 2.13.
 - OOTB non-case class support
 - smaller compilation overhead compared to shapless based solutions (thanks to magnolia <3)
 - programmer friendly and type safe api for partial ignore
+
+## Colors
+
+When running tests through sbt, default diffx's colors work well on both dark and light backgrounds. 
+Unfortunately Intellij Idea forces the default color to red when displaying test's error. 
+This means that it is impossible to print something with the standard default color (either white or black depending on the color scheme).
+
+To have better colors an external information about desired theme is required.
+Specify environment variable `DIFFX_COLOR_THEME` and set it to either `light` or `dark`.
+I had to specify it in `/etc/environment` rather than home profile for Intellij Idea to picked it up.
+
+If anyone has an idea how this could be improved, I am open for suggestions. 
 
 ## Scalatest integration
 

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -34,12 +34,29 @@ trait DiffxEitherSupport {
 }
 
 trait DiffxConsoleSupport {
-  def red(s: String): String = Console.RED + s + Console.RESET
+  def leftColor(s: String)(implicit c: ConsoleColorConfig): String = c.left(s)
+  def rightColor(s: String)(implicit c: ConsoleColorConfig): String = c.right(s)
+  def defaultColor(s: String)(implicit c: ConsoleColorConfig): String = c.default(s)
+  def arrowColor(s: String)(implicit c: ConsoleColorConfig): String = c.arrow(s)
+  def showChange(l: String, r: String)(implicit c: ConsoleColorConfig): String =
+    leftColor(l) + arrowColor(" -> ") + rightColor(r)
+}
+
+case class ConsoleColorConfig(
+    left: String => String,
+    right: String => String,
+    default: String => String,
+    arrow: String => String
+)
+
+object ConsoleColorConfig {
+  implicit val default: ConsoleColorConfig =
+    ConsoleColorConfig(left = magenta, right = green, default = cyan, arrow = red)
+
+  def magenta(s: String): String = Console.MAGENTA + s + Console.RESET
   def green(s: String): String = Console.GREEN + s + Console.RESET
-  def blue(s: String): String = Console.BLUE + s + Console.RESET
-  def pad(s: Any, i: Int = 5): String = (" " * (i - s"$s".length)) + s
-  def arrow(l: String, r: String): String = l + " -> " + r
-  def showChange(l: String, r: String): String = red(l) + " -> " + green(r)
+  def cyan(s: String): String = Console.CYAN + s + Console.RESET
+  def red(s: String): String = Console.RED + s + Console.RESET
 }
 
 trait DiffxOptionSupport {

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -52,14 +52,13 @@ case class ConsoleColorConfig(
 object ConsoleColorConfig {
   val dark: ConsoleColorConfig = ConsoleColorConfig(left = magenta, right = green, default = cyan, arrow = red)
   val light: ConsoleColorConfig = ConsoleColorConfig(default = black, arrow = red, left = magenta, right = blue)
-  val noColors: ConsoleColorConfig =
-    ConsoleColorConfig(default = identity, arrow = identity, right = identity, left = identity)
-  val envDriven: ConsoleColorConfig = ConsoleColorConfig(
-    default = Option(System.getenv("DIFFX_DEFAULT_COLOR")).map(toColor).getOrElse(noColors.default),
-    left = Option(System.getenv("DIFFX_LEFT_COLOR")).map(toColor).getOrElse(noColors.left),
-    right = Option(System.getenv("DIFFX_RIGHT_COLOR")).map(toColor).getOrElse(noColors.right),
-    arrow = Option(System.getenv("DIFFX_ARROW_COLOR")).map(toColor).getOrElse(noColors.arrow)
-  )
+  val normal: ConsoleColorConfig =
+    ConsoleColorConfig(default = identity, arrow = red, right = green, left = red)
+  val envDriven: ConsoleColorConfig = Option(System.getenv("DIFFX_COLOR_THEME")) match {
+    case Some("light") => light
+    case Some("dark")  => dark
+    case _             => normal
+  }
   implicit val default: ConsoleColorConfig = envDriven
 
   def magenta: String => String = toColor(Console.MAGENTA)

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -55,7 +55,13 @@ object ConsoleColorConfig {
 
   val light: ConsoleColorConfig = ConsoleColorConfig(default = black, arrow = red, left = magenta, right = blue)
 
-  implicit val default: ConsoleColorConfig = dark
+  val envDriven: ConsoleColorConfig = ConsoleColorConfig(
+    default = Option(System.getenv("DIFFX_DEFAULT_COLOR")).map(toColor).getOrElse(dark.default),
+    left = Option(System.getenv("DIFFX_LEFT_COLOR")).map(toColor).getOrElse(dark.left),
+    right = Option(System.getenv("DIFFX_RIGHT_COLOR")).map(toColor).getOrElse(dark.right),
+    arrow = Option(System.getenv("DIFFX_ARROW_COLOR")).map(toColor).getOrElse(dark.arrow)
+  )
+  implicit val default: ConsoleColorConfig = envDriven
 
   def magenta(s: String): String = Console.MAGENTA + s + Console.RESET
   def green(s: String): String = Console.GREEN + s + Console.RESET
@@ -63,6 +69,8 @@ object ConsoleColorConfig {
   def cyan(s: String): String = Console.CYAN + s + Console.RESET
   def red(s: String): String = Console.RED + s + Console.RESET
   def black(s: String): String = Console.BLACK + s + Console.RESET
+
+  private def toColor(color: String) = { s: String => color + s + Console.RESET }
 }
 
 trait DiffxOptionSupport {

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -50,13 +50,19 @@ case class ConsoleColorConfig(
 )
 
 object ConsoleColorConfig {
-  implicit val default: ConsoleColorConfig =
+  val dark: ConsoleColorConfig =
     ConsoleColorConfig(left = magenta, right = green, default = cyan, arrow = red)
+
+  val light: ConsoleColorConfig = ConsoleColorConfig(default = black, arrow = red, left = magenta, right = blue)
+
+  implicit val default: ConsoleColorConfig = dark
 
   def magenta(s: String): String = Console.MAGENTA + s + Console.RESET
   def green(s: String): String = Console.GREEN + s + Console.RESET
+  def blue(s: String): String = Console.BLUE + s + Console.RESET
   def cyan(s: String): String = Console.CYAN + s + Console.RESET
   def red(s: String): String = Console.RED + s + Console.RESET
+  def black(s: String): String = Console.BLACK + s + Console.RESET
 }
 
 trait DiffxOptionSupport {

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -50,14 +50,10 @@ case class ConsoleColorConfig(
 )
 
 object ConsoleColorConfig {
-  val dark: ConsoleColorConfig =
-    ConsoleColorConfig(left = magenta, right = green, default = cyan, arrow = red)
-
+  val dark: ConsoleColorConfig = ConsoleColorConfig(left = magenta, right = green, default = cyan, arrow = red)
   val light: ConsoleColorConfig = ConsoleColorConfig(default = black, arrow = red, left = magenta, right = blue)
-
   val noColors: ConsoleColorConfig =
     ConsoleColorConfig(default = identity, arrow = identity, right = identity, left = identity)
-
   val envDriven: ConsoleColorConfig = ConsoleColorConfig(
     default = Option(System.getenv("DIFFX_DEFAULT_COLOR")).map(toColor).getOrElse(noColors.default),
     left = Option(System.getenv("DIFFX_LEFT_COLOR")).map(toColor).getOrElse(noColors.left),
@@ -66,12 +62,12 @@ object ConsoleColorConfig {
   )
   implicit val default: ConsoleColorConfig = envDriven
 
-  def magenta(s: String): String = Console.MAGENTA + s + Console.RESET
-  def green(s: String): String = Console.GREEN + s + Console.RESET
-  def blue(s: String): String = Console.BLUE + s + Console.RESET
-  def cyan(s: String): String = Console.CYAN + s + Console.RESET
-  def red(s: String): String = Console.RED + s + Console.RESET
-  def black(s: String): String = Console.BLACK + s + Console.RESET
+  def magenta: String => String = toColor(Console.MAGENTA)
+  def green: String => String = toColor(Console.GREEN)
+  def blue: String => String = toColor(Console.BLUE)
+  def cyan: String => String = toColor(Console.CYAN)
+  def red: String => String = toColor(Console.RED)
+  def black: String => String = toColor(Console.BLACK)
 
   private def toColor(color: String) = { s: String => color + s + Console.RESET }
 }

--- a/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
+++ b/core/src/main/scala-common/com.softwaremill.diffx/DiffxSupport.scala
@@ -55,11 +55,14 @@ object ConsoleColorConfig {
 
   val light: ConsoleColorConfig = ConsoleColorConfig(default = black, arrow = red, left = magenta, right = blue)
 
+  val noColors: ConsoleColorConfig =
+    ConsoleColorConfig(default = identity, arrow = identity, right = identity, left = identity)
+
   val envDriven: ConsoleColorConfig = ConsoleColorConfig(
-    default = Option(System.getenv("DIFFX_DEFAULT_COLOR")).map(toColor).getOrElse(dark.default),
-    left = Option(System.getenv("DIFFX_LEFT_COLOR")).map(toColor).getOrElse(dark.left),
-    right = Option(System.getenv("DIFFX_RIGHT_COLOR")).map(toColor).getOrElse(dark.right),
-    arrow = Option(System.getenv("DIFFX_ARROW_COLOR")).map(toColor).getOrElse(dark.arrow)
+    default = Option(System.getenv("DIFFX_DEFAULT_COLOR")).map(toColor).getOrElse(noColors.default),
+    left = Option(System.getenv("DIFFX_LEFT_COLOR")).map(toColor).getOrElse(noColors.left),
+    right = Option(System.getenv("DIFFX_RIGHT_COLOR")).map(toColor).getOrElse(noColors.right),
+    arrow = Option(System.getenv("DIFFX_ARROW_COLOR")).map(toColor).getOrElse(noColors.arrow)
   )
   implicit val default: ConsoleColorConfig = envDriven
 

--- a/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
@@ -5,9 +5,9 @@ import DiffResult._
 trait DiffResult extends Product with Serializable {
   def isIdentical: Boolean
 
-  def show: String = showIndented(indentLevel)
+  def show(implicit c: ConsoleColorConfig): String = showIndented(indentLevel)
 
-  private[diffx] def showIndented(indent: Int): String
+  private[diffx] def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String
 }
 
 object DiffResult {
@@ -15,33 +15,33 @@ object DiffResult {
 }
 
 case class DiffResultObject(name: String, fields: Map[String, DiffResult]) extends DiffResultDifferent {
-  override private[diffx] def showIndented(indent: Int): String = {
-    val showFields = fields.map(f => s"${i(indent)}${f._1}: ${f._2.showIndented(indent + indentLevel)}")
-    s"""$name(
-       |${showFields.mkString(",\n")})""".stripMargin
+  override private[diffx] def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
+    val showFields =
+      fields.map(f => s"${i(indent)}${defaultColor(s"${f._1}:")} ${f._2.showIndented(indent + indentLevel)}")
+    defaultColor(s"$name(") + s"\n${showFields.mkString(defaultColor(",") + "\n")}" + defaultColor(")")
   }
 }
 
 case class DiffResultMap(fields: Map[DiffResult, DiffResult]) extends DiffResultDifferent {
-  override private[diffx] def showIndented(indent: Int): String = {
+  override private[diffx] def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
     val showFields =
       fields.map(f =>
-        s"${i(indent)}${f._1.showIndented(indent + indentLevel)}: ${f._2.showIndented(indent + indentLevel)}"
+        s"${i(indent)}${defaultColor(s"${f._1.showIndented(indent + indentLevel)}")}" + defaultColor(": ") + s"${f._2
+          .showIndented(indent + indentLevel)}"
       )
-    s"""Map(
-       |${showFields.mkString(",\n")})""".stripMargin
+    defaultColor("Map(") + s"\n${showFields.mkString(defaultColor(",") + "\n")}" + defaultColor(")")
   }
 }
 
 case class DiffResultSet(diffs: List[DiffResult]) extends DiffResultDifferent {
-  override private[diffx] def showIndented(indent: Int): String = {
+  override private[diffx] def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
     val showFields = diffs.map(f => s"${i(indent)}${f.showIndented(indent + indentLevel)}")
-    showFields.mkString("Set(\n", ",\n", ")")
+    showFields.mkString(defaultColor("Set(\n"), ",\n", defaultColor(")"))
   }
 }
 
 case class DiffResultString(diffs: List[DiffResult]) extends DiffResultDifferent {
-  override private[diffx] def showIndented(indent: Int): String = {
+  override private[diffx] def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
     s""""${diffs.map(_.showIndented(indent)).mkString("\n")}""""
   }
 }
@@ -53,23 +53,23 @@ trait DiffResultDifferent extends DiffResult {
 }
 
 case class DiffResultValue[T](left: T, right: T) extends DiffResultDifferent {
-  override def showIndented(indent: Int): String = showChange(s"$left", s"$right")
+  override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = showChange(s"$left", s"$right")
 }
 
 case class Identical[T](value: T) extends DiffResult {
   override def isIdentical: Boolean = true
 
-  override def showIndented(indent: Int): String = s"$value"
+  override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = defaultColor(s"$value")
 }
 
 case class DiffResultMissing[T](value: T) extends DiffResultDifferent {
-  override def showIndented(indent: Int): String = {
-    red(s"$value")
+  override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
+    leftColor(s"$value")
   }
 }
 
 case class DiffResultAdditional[T](value: T) extends DiffResultDifferent {
-  override def showIndented(indent: Int): String = {
-    green(s"$value")
+  override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
+    rightColor(s"$value")
   }
 }

--- a/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport {
   implicit val colorConfig: ConsoleColorConfig =
-    ConsoleColorConfig.dark.copy(default = identity, arrow = identity, right = identity, left = identity)
+    ConsoleColorConfig(default = identity, arrow = identity, right = identity, left = identity)
 
   "diff set output" - {
     "it should show a simple difference" in {

--- a/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport {
   implicit val colorConfig: ConsoleColorConfig =
-    ConsoleColorConfig.default.copy(default = identity, arrow = identity, right = identity, left = identity)
+    ConsoleColorConfig.dark.copy(default = identity, arrow = identity, right = identity, left = identity)
 
   "diff set output" - {
     "it should show a simple difference" in {

--- a/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
@@ -4,13 +4,16 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport {
+  implicit val colorConfig: ConsoleColorConfig =
+    ConsoleColorConfig.default.copy(default = identity, arrow = identity, right = identity, left = identity)
+
   "diff set output" - {
     "it should show a simple difference" in {
       val output = DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).show
       output shouldBe
         s"""Set(
           |     a,
-          |     ${red("1")} -> ${green("2")})""".stripMargin
+          |     1 -> 2)""".stripMargin
     }
 
     "it should show an indented difference" in {
@@ -18,7 +21,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
       output shouldBe
         s"""Set(
            |     a,
-           |     ${red("1")} -> ${green("2")})""".stripMargin
+           |     1 -> 2)""".stripMargin
     }
 
     "it should show a nested list difference" in {
@@ -35,7 +38,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
       output shouldBe
         s"""Set(
           |     null,
-          |     ${red("null")} -> ${green("null")})""".stripMargin
+          |     null -> null)""".stripMargin
     }
   }
 
@@ -45,8 +48,8 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
         DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3))).show
       output shouldBe
         s"""Map(
-           |     a: ${red("1")} -> ${green("2")},
-           |     ${red("b")}: ${red("3")})""".stripMargin
+           |     a: 1 -> 2,
+           |     b: 3)""".stripMargin
     }
 
     "it should show an indented diff" in {
@@ -55,8 +58,8 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
           .showIndented(5)
       output shouldBe
         s"""Map(
-           |     a: ${red("1")} -> ${green("2")},
-           |     ${red("b")}: ${red("3")})""".stripMargin
+           |     a: 1 -> 2,
+           |     b: 3)""".stripMargin
     }
 
     "it should show a nested diff" in {
@@ -65,7 +68,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
       output shouldBe
         s"""Map(
            |     a: Map(
-           |          b: ${red("1")} -> ${green("2")}))""".stripMargin
+           |          b: 1 -> 2))""".stripMargin
     }
   }
 }

--- a/scalatest/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
+++ b/scalatest/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
@@ -1,16 +1,16 @@
 package com.softwaremill.diffx.scalatest
 
-import com.softwaremill.diffx.{Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait DiffMatcher {
-  def matchTo[A: Diff](left: A): DiffForMatcher[A] = DiffForMatcher(left)
+  def matchTo[A: Diff](left: A)(implicit c: ConsoleColorConfig): DiffForMatcher[A] = new DiffForMatcher(left)
 
-  case class DiffForMatcher[A: Diff](right: A) extends Matcher[A] {
+  class DiffForMatcher[A: Diff](right: A)(implicit c: ConsoleColorConfig) extends Matcher[A] {
     override def apply(left: A): MatchResult = Diff[A].apply(left, right) match {
       case c: DiffResultDifferent =>
-        println(c.show)
-        MatchResult(matches = false, "Matching error", "a co to?")
+        val diff = c.show.split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
+        MatchResult(matches = false, s"Matching error:\n$diff", "")
       case _ => MatchResult(matches = true, "", "")
     }
   }

--- a/scalatest/src/test/scala/com/softwaremill/diffx/scalatest/DiffMatcherTest.scala
+++ b/scalatest/src/test/scala/com/softwaremill/diffx/scalatest/DiffMatcherTest.scala
@@ -5,12 +5,12 @@ import org.scalatest.matchers.should.Matchers
 
 class DiffMatcherTest extends AnyFlatSpec with Matchers with DiffMatcher {
   val right: Foo = Foo(
-    Bar("asdf", 5),
+    Bar("asdf", 5, Map("a" -> 2)),
     List(123, 1234),
-    Some(Bar("asdf", 5))
+    Some(Bar("asdf", 5, Map("a" -> 2)))
   )
   val left: Foo = Foo(
-    Bar("asdf", 66),
+    Bar("asdf", 66, Map("b" -> 3)),
     List(1234),
     Some(right)
   )
@@ -20,5 +20,5 @@ class DiffMatcherTest extends AnyFlatSpec with Matchers with DiffMatcher {
   }
 }
 sealed trait Parent
-case class Bar(s: String, i: Int) extends Parent
+case class Bar(s: String, i: Int, ss: Map[String, Int]) extends Parent
 case class Foo(bar: Bar, b: List[Int], parent: Option[Parent]) extends Parent

--- a/specs2/src/main/scala/com/softwaremill/diffx/specs2/DiffMatcher.scala
+++ b/specs2/src/main/scala/com/softwaremill/diffx/specs2/DiffMatcher.scala
@@ -1,10 +1,10 @@
 package com.softwaremill.diffx.specs2
 
-import com.softwaremill.diffx.{Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
 import org.specs2.matcher.{Expectable, MatchResult, Matcher}
 
 trait DiffMatcher {
-  def matchTo[A: Diff](left: A): DiffForMatcher[A] = DiffForMatcher(left)
+  def matchTo[A: Diff](left: A)(implicit c: ConsoleColorConfig): DiffForMatcher[A] = DiffForMatcher(left)
 
   case class DiffForMatcher[A: Diff](right: A) extends Matcher[A] {
     override def apply[S <: A](left: Expectable[S]): MatchResult[S] = {


### PR DESCRIPTION
* Allow colors overriding
* Rendering improvements

This fixes #74 