### PR TITLE
Swap left and right show for missing and additional diff result (Fixes #90)

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffResult.scala
@@ -64,12 +64,12 @@ case class Identical[T](value: T) extends DiffResult {
 
 case class DiffResultMissing[T](value: T) extends DiffResultDifferent {
   override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
-    leftColor(s"$value")
+    rightColor(s"$value")
   }
 }
 
 case class DiffResultAdditional[T](value: T) extends DiffResultDifferent {
   override def showIndented(indent: Int)(implicit c: ConsoleColorConfig): String = {
-    rightColor(s"$value")
+    leftColor(s"$value")
   }
 }

--- a/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/DiffResultTest.scala
@@ -71,4 +71,18 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
            |          b: 1 -> 2))""".stripMargin
     }
   }
+
+  "diff object output" - {
+    "it should show an indented diff with plus and minus signs" in {
+      val colorConfigWithPlusMinus: ConsoleColorConfig =
+        ConsoleColorConfig(default = identity, arrow = identity, right = s => "+" + s, left = s => "-" + s)
+
+      val output = DiffResultObject("List", Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234)))
+        .showIndented(5)(colorConfigWithPlusMinus)
+      output shouldBe
+        s"""List(
+           |     0: -1234 -> +123,
+           |     1: +1234)""".stripMargin
+    }
+  }
 }


### PR DESCRIPTION
As far as I understand, missing and additional string representations should be inverted.
See issue #90 for details.