### PR TITLE
refactor: change the name in DiffMatcher

### DIFF
--- a/scalatest/shared/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
+++ b/scalatest/shared/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
@@ -4,16 +4,13 @@ import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait DiffMatcher {
-  def matchTo[A: Diff](left: A)(implicit c: ConsoleColorConfig): DiffForMatcher[A] = new DiffForMatcher(left)
-
-  class DiffForMatcher[A: Diff](right: A)(implicit c: ConsoleColorConfig) extends Matcher[A] {
-    override def apply(left: A): MatchResult =
-      Diff[A].apply(left, right) match {
-        case c: DiffResultDifferent =>
-          val diff = c.show.split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
-          MatchResult(matches = false, s"Matching error:\n$diff", "")
-        case _ => MatchResult(matches = true, "", "")
-      }
+  def matchTo[A: Diff](right: A)(implicit c: ConsoleColorConfig): Matcher[A] = { left =>
+    Diff[A].apply(left, right) match {
+      case c: DiffResultDifferent =>
+        val diff = c.show.split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
+        MatchResult(matches = false, s"Matching error:\n$diff", "")
+      case _ => MatchResult(matches = true, "", "")
+    }
   }
 }
 


### PR DESCRIPTION
The naming in `DiffMatcher` is a bit confusing. `matchTo` method takes `left` and returns `DiffForMatcher(left)`, but the field in `DiffForMatcher` is named `right`, and the apply method then takes `left`. 
Hope the change is more clearer. 