### PR TITLE
Fix/semi-auto derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
         case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
         case _                       => sourceDir / "scala-2.13-"
       }
-    }
+    },
+    boilerplateSource in Compile := baseDirectory.value.getParentFile / "src" / "main" / "boilerplate"
   )
+  .enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js

--- a/core/src/main/boilerplate/com/softwaremill/diffx/TupleInstances.scala.template
+++ b/core/src/main/boilerplate/com/softwaremill/diffx/TupleInstances.scala.template
@@ -1,0 +1,21 @@
+package com.softwaremill.diffx
+
+trait TupleInstances {
+
+  [2..#def dTuple1[[#T1#]](implicit [#d1: Diff[T1]#]): Diff[Tuple1[[#T1#]]] = new Diff[Tuple1[[#T1#]]] {
+      override def apply(
+          left: ([#T1#]),
+          right: ([#T1#]),
+          toIgnore: List[_root_.com.softwaremill.diffx.FieldPath]
+      ): DiffResult = {
+        val results = List([#"_1" -> d1.apply(left._1, right._1)#]).toMap
+        if (results.values.forall(_.isIdentical)) {
+          Identical(left)
+        } else {
+          DiffResultObject("Tuple1", results)
+        }
+      }
+    }
+    #
+    ]
+}

--- a/core/src/main/boilerplate/com/softwaremill/diffx/TupleInstances.scala.template
+++ b/core/src/main/boilerplate/com/softwaremill/diffx/TupleInstances.scala.template
@@ -2,7 +2,7 @@ package com.softwaremill.diffx
 
 trait TupleInstances {
 
-  [2..#def dTuple1[[#T1#]](implicit [#d1: Diff[T1]#]): Diff[Tuple1[[#T1#]]] = new Diff[Tuple1[[#T1#]]] {
+  [2..#implicit def dTuple1[[#T1#]](implicit [#d1: Diff[T1]#]): Diff[Tuple1[[#T1#]]] = new Diff[Tuple1[[#T1#]]] {
       override def apply(
           left: ([#T1#]),
           right: ([#T1#]),

--- a/core/src/main/scala/com/softwaremill/diffx/Diff.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/Diff.scala
@@ -21,7 +21,7 @@ trait Diff[-T] { outer =>
     }
 }
 
-object Diff extends MiddlePriorityDiff {
+object Diff extends MiddlePriorityDiff with TupleInstances {
   def apply[T: Diff]: Diff[T] = implicitly[Diff[T]]
 
   def identical[T]: Diff[T] = (left: T, _: T, _: List[FieldPath]) => Identical(left)

--- a/core/src/main/scala/com/softwaremill/diffx/Diff.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/Diff.scala
@@ -34,7 +34,10 @@ object Diff extends MiddlePriorityDiff {
   def derived[T]: Derived[Diff[T]] = macro MagnoliaDerivedMacro.derivedGen[T]
 
   implicit val diffForString: Diff[String] = new DiffForString
-  implicit val diffForRange: Diff[Range] = Diff.fallback[Range]
+  implicit val diffForRange: Diff[Range] = Diff.useEquals[Range]
+  implicit val diffForChar: Diff[Char] = Diff.useEquals[Char]
+  implicit val diffForBoolean: Diff[Boolean] = Diff.useEquals[Boolean]
+
   implicit def diffForNumeric[T: Numeric]: Diff[T] = new DiffForNumeric[T]
   implicit def diffForMap[K, V, C[KK, VV] <: scala.collection.Map[KK, VV]](implicit
       ddot: Diff[Option[V]],
@@ -46,6 +49,8 @@ object Diff extends MiddlePriorityDiff {
       ddt: Diff[T],
       matcher: ObjectMatcher[T]
   ): Diff[C[T]] = new DiffForSet[T, C](ddt, matcher)
+  implicit def diffForEither[L, R](implicit ld: Diff[L], rd: Diff[R]): Diff[Either[L, R]] =
+    new DiffForEither[L, R](ld, rd)
 }
 
 trait MiddlePriorityDiff extends DiffMagnoliaDerivation with LowPriorityDiff {

--- a/core/src/main/scala/com/softwaremill/diffx/IgnoreMacro.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/IgnoreMacro.scala
@@ -2,9 +2,23 @@ package com.softwaremill.diffx
 
 import scala.annotation.tailrec
 import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 
 object IgnoreMacro {
   private val ShapeInfo = "Path must have shape: _.field1.field2.each.field3.(...)"
+
+  def derivedIgnoreMacro[T: c.WeakTypeTag, U: c.WeakTypeTag](
+      c: whitebox.Context
+  )(path: c.Expr[T => U]): c.Tree = applyDerivedIgnored[T, U](c)(ignoredFromPathMacro(c)(path))
+
+  private def applyDerivedIgnored[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+      path: c.Expr[List[String]]
+  ): c.Tree = {
+    import c.universe._
+    q"""{
+      com.softwaremill.diffx.Derived(${c.prefix}.dd.value.ignoreUnsafe($path:_*))
+     }"""
+  }
 
   def ignoreMacro[T: c.WeakTypeTag, U: c.WeakTypeTag](
       c: blackbox.Context

--- a/core/src/main/scala/com/softwaremill/diffx/generic/auto/DiffDerivation.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/generic/auto/DiffDerivation.scala
@@ -6,4 +6,7 @@ package object auto extends DiffDerivation
 
 trait DiffDerivation extends DiffMagnoliaDerivation {
   implicit def diffForCaseClass[T]: Derived[Diff[T]] = macro MagnoliaDerivedMacro.derivedGen[T]
+
+  // Implicit conversion
+  implicit def unwrapDerivedDiff[T](dd: Derived[Diff[T]]): Diff[T] = dd.value
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForEither.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForEither.scala
@@ -1,0 +1,17 @@
+package com.softwaremill.diffx.instances
+
+import com.softwaremill.diffx.{Diff, DiffResult, DiffResultValue, FieldPath}
+
+private[diffx] class DiffForEither[L, R](ld: Diff[L], rd: Diff[R]) extends Diff[Either[L, R]] {
+  override def apply(
+      left: Either[L, R],
+      right: Either[L, R],
+      toIgnore: List[FieldPath]
+  ): DiffResult = {
+    (left, right) match {
+      case (Left(v1), Left(v2))   => ld.apply(v1, v2, toIgnore)
+      case (Right(v1), Right(v2)) => rd.apply(v1, v2, toIgnore)
+      case (v1, v2)               => DiffResultValue(v1, v2)
+    }
+  }
+}

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
@@ -1,5 +1,7 @@
 package com.softwaremill.diffx.test
 
+import com.softwaremill.diffx.test.ACoproduct.ProductA
+import com.softwaremill.diffx.{Derived, Diff, Identical}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,8 +12,8 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
         |final case class P1(f1: String)
         |final case class P2(f1: P1)
         |
-        |implicit val p1: Diff[P1] = Diff.derived[P1]
-        |implicit val p2: Diff[P2] = Diff.derived[P2]
+        |implicit val p1: Derived[Diff[P1]] = Diff.derived[P1]
+        |implicit val p2: Derived[Diff[P2]] = Diff.derived[P2]
         |""".stripMargin)
   }
 
@@ -21,7 +23,7 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
                      |final case class P1(f1: String)
                      |final case class P2(f1: P1)
                      |
-                     |implicit val p2: Diff[P2] = Diff.derived[P2]
+                     |implicit val p2: Derived[Diff[P2]] = Diff.derived[P2]
                      |""".stripMargin)
   }
 
@@ -35,4 +37,26 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
                      |val p2: Diff[P2] = Diff[P2]
                      |""".stripMargin)
   }
+
+  "should work for coproducts" in {
+    implicit val dACoproduct: Derived[Diff[ACoproduct]] = Diff.derived[ACoproduct]
+
+    Diff.compare[ACoproduct](ProductA("1"), ProductA("1")) shouldBe Identical(
+      ProductA("1")
+    )
+  }
+
+  "should allow ignoring on derived diffs" in {
+    implicit val dACoproduct: Derived[Diff[ProductA]] = Diff.derived[ProductA].ignore(_.id)
+
+    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe Identical(
+      ProductA("1")
+    )
+  }
+}
+
+sealed trait ACoproduct
+object ACoproduct {
+  case class ProductA(id: String) extends ACoproduct
+  case class ProductB(id: String) extends ACoproduct
 }

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
@@ -544,6 +544,48 @@ class DiffTest extends AnyFreeSpec with Matchers {
       compare(e1, e2) shouldBe DiffResultValue(e1, e2)
     }
   }
+  "tuples" - {
+    "tuple2" - {
+      "equal tuples should be identical" in {
+        compare((1, 2), (1, 2)) shouldBe Identical((1, 2))
+      }
+      "different first element should make them different" in {
+        compare((1, 2), (3, 2)) shouldBe DiffResultObject(
+          "Tuple2",
+          Map("_1" -> DiffResultValue(1, 3), "_2" -> Identical(2))
+        )
+      }
+      "different second element should make them different" in {
+        compare((1, 3), (1, 2)) shouldBe DiffResultObject(
+          "Tuple2",
+          Map("_1" -> Identical(1), "_2" -> DiffResultValue(3, 2))
+        )
+      }
+    }
+    "tuple3" - {
+      "equal tuples should be identical" in {
+        compare((1, 2, 3), (1, 2, 3)) shouldBe Identical((1, 2, 3))
+      }
+      "different first element should make them different" in {
+        compare((1, 2, 3), (4, 2, 3)) shouldBe DiffResultObject(
+          "Tuple3",
+          Map("_1" -> DiffResultValue(1, 4), "_2" -> Identical(2), "_3" -> Identical(3))
+        )
+      }
+      "different second element should make them different" in {
+        compare((1, 2, 3), (1, 4, 3)) shouldBe DiffResultObject(
+          "Tuple3",
+          Map("_1" -> Identical(1), "_2" -> DiffResultValue(2, 4), "_3" -> Identical(3))
+        )
+      }
+      "different third element should make them different" in {
+        compare((1, 2, 3), (1, 2, 4)) shouldBe DiffResultObject(
+          "Tuple3",
+          Map("_1" -> Identical(1), "_2" -> Identical(2), "_3" -> DiffResultValue(3, 4))
+        )
+      }
+    }
+  }
 }
 
 case class Person(name: String, age: Int, in: Instant)

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
@@ -528,6 +528,22 @@ class DiffTest extends AnyFreeSpec with Matchers {
       )
     }
   }
+  "either" - {
+    "equal rights should be identical" in {
+      val e1: Either[String, String] = Right("a")
+      compare(e1, e1) shouldBe Identical("a")
+
+    }
+    "equal lefts should be identical" in {
+      val e1: Either[String, String] = Left("a")
+      compare(e1, e1) shouldBe Identical("a")
+    }
+    "left and right should be different" in {
+      val e1: Either[String, String] = Left("a")
+      val e2: Either[String, String] = Right("a")
+      compare(e1, e2) shouldBe DiffResultValue(e1, e2)
+    }
+  }
 }
 
 case class Person(name: String, age: Int, in: Instant)

--- a/docs-sources/README.md
+++ b/docs-sources/README.md
@@ -71,16 +71,6 @@ Will result in:
 ## Derivation
 
 Diffx supports auto and semi-auto derivation.
-To use auto derivation add following import
-
-`import com.softwaremill.diffx.generic.auto._`
-
-or 
-
-extend trait
-
-`com.softwaremill.diffx.generic.DiffDerivation`
-
 
 For semi-auto derivation you don't need any additional import, just define your instances using:
 ```scala mdoc:compile-only
@@ -90,6 +80,19 @@ case class Basket(products: List[Product])
 val productDiff = Diff.derived[Product]
 val basketDiff = Diff.derived[Basket]
 ```
+
+To use auto derivation add following import
+
+`import com.softwaremill.diffx.generic.auto._`
+
+or
+
+extend trait
+
+`com.softwaremill.diffx.generic.DiffDerivation`
+
+**Auto derivation will have a huge impact on compilation times**, because of that it is recommended to use `semi-auto` derivation.
+
 
 ## Colors
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-extra" % "1
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.14")
+addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
This pr contains:
1. fix for semi-auto derivation of coproducts (more in #218)
   - semi-auto will now always yield `Derived[Diff]`
   - there is no implicit conversion from`Derived[Diff]` to `Diff` for semi-auto
   - because of that, `ignore` and `contramap` methods were added on `Derived[Diff]`
2. instance for Either so it doesn't have to be generated 
3. auto-generated instanced for tuple to improve compilation times even further
