### PR TITLE
Display ignored fields as ignored

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/Diff.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/Diff.scala
@@ -31,7 +31,6 @@ trait Diff[-T] { outer =>
 object Diff extends MiddlePriorityDiff with TupleInstances {
   def apply[T: Diff]: Diff[T] = implicitly[Diff[T]]
 
-  def identical[T]: Diff[T] = (left: T, _: T, _: DiffContext) => Identical(left)
   def ignored[T]: Diff[T] = (_: T, _: T, _: DiffContext) => DiffResult.Ignored
 
   def compare[T: Diff](left: T, right: T): DiffResult = apply[T].apply(left, right)

--- a/core/src/main/scala/com/softwaremill/diffx/DiffxSupport.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffxSupport.scala
@@ -12,7 +12,7 @@ trait DiffxSupport extends DiffxEitherSupport with DiffxConsoleSupport with Diff
     if ((left == null && right != null) || (left != null && right == null)) {
       DiffResultValue(left, right)
     } else if (left == null && right == null) {
-      Identical(null)
+      IdenticalValue(null)
     } else {
       compareNotNull(left, right)
     }

--- a/core/src/main/scala/com/softwaremill/diffx/TupleInstances.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/TupleInstances.scala
@@ -10,7 +10,7 @@ trait TupleInstances {
     ): DiffResult = {
       val results = List("_1" -> d1.apply(left._1, right._1), "_2" -> d2.apply(left._2, right._2)).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple2", results)
       }
@@ -30,7 +30,7 @@ trait TupleInstances {
           "_3" -> d3.apply(left._3, right._3)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple3", results)
         }
@@ -55,7 +55,7 @@ trait TupleInstances {
         "_4" -> d4.apply(left._4, right._4)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple4", results)
       }
@@ -82,7 +82,7 @@ trait TupleInstances {
         "_5" -> d5.apply(left._5, right._5)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple5", results)
       }
@@ -111,7 +111,7 @@ trait TupleInstances {
         "_6" -> d6.apply(left._6, right._6)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple6", results)
       }
@@ -142,7 +142,7 @@ trait TupleInstances {
         "_7" -> d7.apply(left._7, right._7)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple7", results)
       }
@@ -175,7 +175,7 @@ trait TupleInstances {
         "_8" -> d8.apply(left._8, right._8)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple8", results)
       }
@@ -210,7 +210,7 @@ trait TupleInstances {
         "_9" -> d9.apply(left._9, right._9)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple9", results)
       }
@@ -248,7 +248,7 @@ trait TupleInstances {
           "_10" -> d10.apply(left._10, right._10)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple10", results)
         }
@@ -288,7 +288,7 @@ trait TupleInstances {
           "_11" -> d11.apply(left._11, right._11)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple11", results)
         }
@@ -330,7 +330,7 @@ trait TupleInstances {
           "_12" -> d12.apply(left._12, right._12)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple12", results)
         }
@@ -374,7 +374,7 @@ trait TupleInstances {
           "_13" -> d13.apply(left._13, right._13)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple13", results)
         }
@@ -420,7 +420,7 @@ trait TupleInstances {
           "_14" -> d14.apply(left._14, right._14)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple14", results)
         }
@@ -468,7 +468,7 @@ trait TupleInstances {
           "_15" -> d15.apply(left._15, right._15)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple15", results)
         }
@@ -518,7 +518,7 @@ trait TupleInstances {
           "_16" -> d16.apply(left._16, right._16)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple16", results)
         }
@@ -570,7 +570,7 @@ trait TupleInstances {
           "_17" -> d17.apply(left._17, right._17)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple17", results)
         }
@@ -624,7 +624,7 @@ trait TupleInstances {
           "_18" -> d18.apply(left._18, right._18)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple18", results)
         }
@@ -680,7 +680,7 @@ trait TupleInstances {
           "_19" -> d19.apply(left._19, right._19)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple19", results)
         }
@@ -739,7 +739,7 @@ trait TupleInstances {
           "_20" -> d20.apply(left._20, right._20)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple20", results)
         }
@@ -800,7 +800,7 @@ trait TupleInstances {
           "_21" -> d21.apply(left._21, right._21)
         ).toMap
         if (results.values.forall(_.isIdentical)) {
-          Identical(left)
+          IdenticalValue(left)
         } else {
           DiffResultObject("Tuple21", results)
         }
@@ -888,7 +888,7 @@ trait TupleInstances {
         "_22" -> d22.apply(left._22, right._22)
       ).toMap
       if (results.values.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultObject("Tuple22", results)
       }

--- a/core/src/main/scala/com/softwaremill/diffx/TupleInstances.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/TupleInstances.scala
@@ -9,11 +9,7 @@ trait TupleInstances {
         context: DiffContext
     ): DiffResult = {
       val results = List("_1" -> d1.apply(left._1, right._1), "_2" -> d2.apply(left._2, right._2)).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple2", results)
-      }
+      DiffResultObject("Tuple2", results)
     }
   }
 
@@ -29,11 +25,7 @@ trait TupleInstances {
           "_2" -> d2.apply(left._2, right._2),
           "_3" -> d3.apply(left._3, right._3)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple3", results)
-        }
+        DiffResultObject("Tuple3", results)
       }
     }
 
@@ -54,11 +46,7 @@ trait TupleInstances {
         "_3" -> d3.apply(left._3, right._3),
         "_4" -> d4.apply(left._4, right._4)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple4", results)
-      }
+      DiffResultObject("Tuple4", results)
     }
   }
 
@@ -81,11 +69,7 @@ trait TupleInstances {
         "_4" -> d4.apply(left._4, right._4),
         "_5" -> d5.apply(left._5, right._5)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple5", results)
-      }
+      DiffResultObject("Tuple5", results)
     }
   }
 
@@ -110,11 +94,7 @@ trait TupleInstances {
         "_5" -> d5.apply(left._5, right._5),
         "_6" -> d6.apply(left._6, right._6)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple6", results)
-      }
+      DiffResultObject("Tuple6", results)
     }
   }
 
@@ -141,11 +121,7 @@ trait TupleInstances {
         "_6" -> d6.apply(left._6, right._6),
         "_7" -> d7.apply(left._7, right._7)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple7", results)
-      }
+      DiffResultObject("Tuple7", results)
     }
   }
 
@@ -174,11 +150,7 @@ trait TupleInstances {
         "_7" -> d7.apply(left._7, right._7),
         "_8" -> d8.apply(left._8, right._8)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple8", results)
-      }
+      DiffResultObject("Tuple8", results)
     }
   }
 
@@ -209,11 +181,7 @@ trait TupleInstances {
         "_8" -> d8.apply(left._8, right._8),
         "_9" -> d9.apply(left._9, right._9)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple9", results)
-      }
+      DiffResultObject("Tuple9", results)
     }
   }
 
@@ -247,11 +215,7 @@ trait TupleInstances {
           "_9" -> d9.apply(left._9, right._9),
           "_10" -> d10.apply(left._10, right._10)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple10", results)
-        }
+        DiffResultObject("Tuple10", results)
       }
     }
 
@@ -287,11 +251,7 @@ trait TupleInstances {
           "_10" -> d10.apply(left._10, right._10),
           "_11" -> d11.apply(left._11, right._11)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple11", results)
-        }
+        DiffResultObject("Tuple11", results)
       }
     }
 
@@ -329,11 +289,7 @@ trait TupleInstances {
           "_11" -> d11.apply(left._11, right._11),
           "_12" -> d12.apply(left._12, right._12)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple12", results)
-        }
+        DiffResultObject("Tuple12", results)
       }
     }
 
@@ -419,11 +375,7 @@ trait TupleInstances {
           "_13" -> d13.apply(left._13, right._13),
           "_14" -> d14.apply(left._14, right._14)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple14", results)
-        }
+        DiffResultObject("Tuple14", results)
       }
     }
 
@@ -467,11 +419,7 @@ trait TupleInstances {
           "_14" -> d14.apply(left._14, right._14),
           "_15" -> d15.apply(left._15, right._15)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple15", results)
-        }
+        DiffResultObject("Tuple15", results)
       }
     }
 
@@ -517,11 +465,7 @@ trait TupleInstances {
           "_15" -> d15.apply(left._15, right._15),
           "_16" -> d16.apply(left._16, right._16)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple16", results)
-        }
+        DiffResultObject("Tuple16", results)
       }
     }
 
@@ -569,11 +513,7 @@ trait TupleInstances {
           "_16" -> d16.apply(left._16, right._16),
           "_17" -> d17.apply(left._17, right._17)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple17", results)
-        }
+        DiffResultObject("Tuple17", results)
       }
     }
 
@@ -623,11 +563,7 @@ trait TupleInstances {
           "_17" -> d17.apply(left._17, right._17),
           "_18" -> d18.apply(left._18, right._18)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple18", results)
-        }
+        DiffResultObject("Tuple18", results)
       }
     }
 
@@ -679,11 +615,7 @@ trait TupleInstances {
           "_18" -> d18.apply(left._18, right._18),
           "_19" -> d19.apply(left._19, right._19)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple19", results)
-        }
+        DiffResultObject("Tuple19", results)
       }
     }
 
@@ -738,11 +670,7 @@ trait TupleInstances {
           "_19" -> d19.apply(left._19, right._19),
           "_20" -> d20.apply(left._20, right._20)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple20", results)
-        }
+        DiffResultObject("Tuple20", results)
       }
     }
 
@@ -799,11 +727,7 @@ trait TupleInstances {
           "_20" -> d20.apply(left._20, right._20),
           "_21" -> d21.apply(left._21, right._21)
         ).toMap
-        if (results.values.forall(_.isIdentical)) {
-          IdenticalValue(left)
-        } else {
-          DiffResultObject("Tuple21", results)
-        }
+        DiffResultObject("Tuple21", results)
       }
     }
 
@@ -887,11 +811,7 @@ trait TupleInstances {
         "_21" -> d21.apply(left._21, right._21),
         "_22" -> d22.apply(left._22, right._22)
       ).toMap
-      if (results.values.forall(_.isIdentical)) {
-        IdenticalValue(left)
-      } else {
-        DiffResultObject("Tuple22", results)
-      }
+      DiffResultObject("Tuple22", results)
     }
   }
 

--- a/core/src/main/scala/com/softwaremill/diffx/generic/DiffMagnoliaDerivation.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/generic/DiffMagnoliaDerivation.scala
@@ -1,6 +1,14 @@
 package com.softwaremill.diffx.generic
 
-import com.softwaremill.diffx.{Diff, DiffContext, DiffResultObject, DiffResultValue, FieldPath, Identical, nullGuard}
+import com.softwaremill.diffx.{
+  Diff,
+  DiffContext,
+  DiffResultObject,
+  DiffResultValue,
+  FieldPath,
+  IdenticalValue,
+  nullGuard
+}
 import magnolia._
 
 import scala.collection.immutable.ListMap
@@ -16,11 +24,7 @@ trait DiffMagnoliaDerivation extends LowPriority {
         val fieldDiff = context.getOverride(p.label).map(_.asInstanceOf[Diff[p.PType]]).getOrElse(p.typeclass)
         p.label -> fieldDiff(lType, pType, context.getNextStep(p.label))
       }: _*)
-      if (map.values.forall(p => p.isIdentical)) {
-        Identical(left)
-      } else {
-        DiffResultObject(ctx.typeName.short, map)
-      }
+      DiffResultObject(ctx.typeName.short, map)
     }
   }
 
@@ -43,7 +47,7 @@ trait LowPriority {
       if (left != right) {
         DiffResultValue(left, right)
       } else {
-        Identical(left)
+        IdenticalValue(left)
       }
     }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/ApproximateDiffForNumeric.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/ApproximateDiffForNumeric.scala
@@ -8,7 +8,7 @@ private[diffx] class ApproximateDiffForNumeric[T: Numeric](epsilon: T) extends D
     if (numeric.lt(epsilon, numeric.abs(numeric.minus(left, right)))) {
       DiffResultValue(left, right)
     } else {
-      Identical(left)
+      IdenticalValue(left)
     }
   }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForIterable.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForIterable.scala
@@ -32,10 +32,6 @@ private[diffx] class DiffForIterable[T, C[W] <: Iterable[W]](
       val matchedDiffs = matchedInstances.map { case (l, r) => l._1 -> dt(l._2, r._2, context) }.toList
 
       val diffs = ListMap((matchedDiffs ++ leftDiffs ++ rightDiffs).map { case (k, v) => k.toString -> v }: _*)
-      if (diffs.forall { case (_, v) => v.isIdentical }) {
-        Identical(left)
-      } else {
-        DiffResultObject("List", diffs)
-      }
+      DiffResultObject("List", diffs)
   }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForMap.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForMap.scala
@@ -28,10 +28,6 @@ private[diffx] class DiffForMap[K, V, C[KK, VV] <: scala.collection.Map[KK, VV]]
     val matchedDiffs = matchedKeys.map { case (l, r) => diffKey(l._1, r._1) -> diffValue(l._2, r._2, context) }.toList
 
     val diffs = leftDiffs ++ rightDiffs ++ matchedDiffs
-    if (diffs.forall(p => p._1.isIdentical && p._2.isIdentical)) {
-      Identical(left)
-    } else {
-      DiffResultMap(diffs.toMap)
-    }
+    DiffResultMap(diffs.toMap)
   }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForNumeric.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForNumeric.scala
@@ -8,7 +8,7 @@ private[diffx] class DiffForNumeric[T: Numeric] extends Diff[T] {
     if (!numeric.equiv(left, right)) {
       DiffResultValue(left, right)
     } else {
-      Identical(left)
+      IdenticalValue(left)
     }
   }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForOption.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForOption.scala
@@ -6,7 +6,7 @@ private[diffx] class DiffForOption[T](dt: Diff[T]) extends Diff[Option[T]] {
   override def apply(left: Option[T], right: Option[T], context: DiffContext): DiffResult = {
     (left, right) match {
       case (Some(l), Some(r)) => dt.apply(l, r, context)
-      case (None, None)       => Identical(None)
+      case (None, None)       => IdenticalValue(None)
       case (l, r)             => DiffResultValue(l, r)
     }
   }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForSet.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForSet.scala
@@ -29,10 +29,6 @@ private[diffx] class DiffForSet[T, C[W] <: scala.collection.Set[W]](dt: Diff[T],
       matchedDiffs: List[DiffResult]
   ): DiffResult = {
     val diffs = leftDiffs ++ rightDiffs ++ matchedDiffs
-    if (diffs.forall(_.isIdentical)) {
-      Identical(left)
-    } else {
-      DiffResultSet(diffs)
-    }
+    DiffResultSet(diffs)
   }
 }

--- a/core/src/main/scala/com/softwaremill/diffx/instances/DiffForString.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/instances/DiffForString.scala
@@ -14,7 +14,7 @@ private[diffx] class DiffForString extends Diff[String] {
         (leftAsMap(i), rightAsMap(i)) match {
           case (Some(lv), Some(rv)) =>
             if (lv == rv) {
-              Identical(lv)
+              IdenticalValue(lv)
             } else {
               DiffResultValue(lv, rv)
             }
@@ -24,7 +24,7 @@ private[diffx] class DiffForString extends Diff[String] {
         }
       }.toList
       if (partialResults.forall(_.isIdentical)) {
-        Identical(left)
+        IdenticalValue(left)
       } else {
         DiffResultString(partialResults)
       }

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
@@ -17,7 +17,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
     implicit val d: Diff[Person] = Derived[Diff[Person]].ignore(_.name)
     compare(p1, p2) shouldBe DiffResultObject(
       "Person",
-      Map("name" -> Identical("<ignored>"), "age" -> DiffResultValue(22, 11), "in" -> Identical(instant))
+      Map("name" -> IdenticalValue("<ignored>"), "age" -> DiffResultValue(22, 11), "in" -> IdenticalValue(instant))
     )
   }
 
@@ -25,7 +25,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
     implicit val d: Diff[Person] = Derived[Diff[Person]].ignore(_.name)
     compare(p1, p2) shouldBe DiffResultObject(
       "Person",
-      Map("name" -> Identical("<ignored>"), "age" -> DiffResultValue(22, 11), "in" -> Identical(instant))
+      Map("name" -> IdenticalValue("<ignored>"), "age" -> DiffResultValue(22, 11), "in" -> IdenticalValue(instant))
     )
   }
 
@@ -33,7 +33,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
     implicit val d: Diff[Person] = Derived[Diff[Person]]
       .ignore(_.name)
       .ignore(_.age)
-    compare(p1, p2) shouldBe Identical(p1)
+    compare(p1, p2) shouldBe IdenticalValue(p1)
   }
 
   it should "compare lists using explicit object matcher comparator" in {
@@ -44,7 +44,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
       .withListMatcher(
         ObjectMatcher.byValue[Int, Person](ObjectMatcher.by(_.name))
       )
-    compare(o1, o2) shouldBe Identical(Organization(List(p1, p2)))
+    compare(o1, o2) shouldBe IdenticalValue(Organization(List(p1, p2)))
   }
 
   it should "ignore only on right" in {
@@ -54,12 +54,12 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
 
     implicit val wrapperDiff: Diff[Wrapper] = Derived[Diff[Wrapper]].ignore(_.e.eachRight.name)
 
-    compare(e1, e2) shouldBe Identical(e1)
+    compare(e1, e2) shouldBe IdenticalValue(e1)
 
     val e3 = Wrapper(Left(p1))
     val e4 = Wrapper(Left(p1.copy(name = p1.name + "_modified")))
 
-    compare(e3, e4) should not be an[Identical[_]]
+    compare(e3, e4) should not be an[IdenticalValue[_]]
   }
 
   it should "ignore only on left" in {
@@ -69,11 +69,11 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
 
     implicit val wrapperDiff: Diff[Wrapper] = Derived[Diff[Wrapper]].ignore(_.e.eachLeft.name)
 
-    compare(e1, e2) should not be an[Identical[_]]
+    compare(e1, e2) should not be an[IdenticalValue[_]]
     val e3 = Wrapper(Left(p1))
     val e4 = Wrapper(Left(p1.copy(name = p1.name + "_modified")))
 
-    compare(e3, e4) shouldBe an[Identical[_]]
+    compare(e3, e4) shouldBe an[IdenticalValue[_]]
   }
 
   it should "match map entries by values" in {
@@ -95,9 +95,9 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
               "KeyModel",
               Map(
                 "id" -> DiffResultValue(uuid1, uuid2),
-                "name" -> Identical("k1")
+                "name" -> IdenticalValue("k1")
               )
-            ) -> Identical("val1")
+            ) -> IdenticalValue("val1")
           )
         )
       )
@@ -114,10 +114,14 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
       Map(
         "workers" -> DiffResultSet(
           List(
-            Identical(p1),
+            IdenticalValue(p1),
             DiffResultObject(
               "Person",
-              Map("name" -> Identical(p2.name), "age" -> DiffResultValue(p2.age, p2m.age), "in" -> Identical(p1.in))
+              Map(
+                "name" -> IdenticalValue(p2.name),
+                "age" -> DiffResultValue(p2.age, p2m.age),
+                "in" -> IdenticalValue(p1.in)
+              )
             )
           )
         )

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
@@ -33,7 +33,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
     implicit val d: Diff[Person] = Derived[Diff[Person]]
       .ignore(_.name)
       .ignore(_.age)
-    compare(p1, p2) shouldBe IdenticalValue(p1)
+    compare(p1, p2).isIdentical shouldBe true
   }
 
   it should "compare lists using explicit object matcher comparator" in {
@@ -44,7 +44,7 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
       .withListMatcher(
         ObjectMatcher.byValue[Int, Person](ObjectMatcher.by(_.name))
       )
-    compare(o1, o2) shouldBe IdenticalValue(Organization(List(p1, p2)))
+    compare(o1, o2).isIdentical shouldBe true
   }
 
   it should "ignore only on right" in {
@@ -54,12 +54,12 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
 
     implicit val wrapperDiff: Diff[Wrapper] = Derived[Diff[Wrapper]].ignore(_.e.eachRight.name)
 
-    compare(e1, e2) shouldBe IdenticalValue(e1)
+    compare(e1, e2).isIdentical shouldBe true
 
     val e3 = Wrapper(Left(p1))
     val e4 = Wrapper(Left(p1.copy(name = p1.name + "_modified")))
 
-    compare(e3, e4) should not be an[IdenticalValue[_]]
+    compare(e3, e4).isIdentical shouldBe false
   }
 
   it should "ignore only on left" in {
@@ -69,11 +69,11 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
 
     implicit val wrapperDiff: Diff[Wrapper] = Derived[Diff[Wrapper]].ignore(_.e.eachLeft.name)
 
-    compare(e1, e2) should not be an[IdenticalValue[_]]
+    compare(e1, e2).isIdentical shouldBe false
     val e3 = Wrapper(Left(p1))
     val e4 = Wrapper(Left(p1.copy(name = p1.name + "_modified")))
 
-    compare(e3, e4) shouldBe an[IdenticalValue[_]]
+    compare(e3, e4).isIdentical shouldBe true
   }
 
   it should "match map entries by values" in {
@@ -114,7 +114,14 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers {
       Map(
         "workers" -> DiffResultSet(
           List(
-            IdenticalValue(p1),
+            DiffResultObject(
+              "Person",
+              Map(
+                "name" -> IdenticalValue(p1.name),
+                "age" -> IdenticalValue(p1.age),
+                "in" -> IdenticalValue(p1.in)
+              )
+            ),
             DiffResultObject(
               "Person",
               Map(

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffResultTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffResultTest.scala
@@ -10,7 +10,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
 
   "diff set output" - {
     "it should show a simple difference" in {
-      val output = DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).show()
+      val output = DiffResultSet(List(IdenticalValue("a"), DiffResultValue("1", "2"))).show()
       output shouldBe
         s"""Set(
           |     a,
@@ -19,7 +19,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
 
     "it should show an indented difference" in {
       val output =
-        DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).show()
+        DiffResultSet(List(IdenticalValue("a"), DiffResultValue("1", "2"))).show()
       output shouldBe
         s"""Set(
            |     a,
@@ -27,7 +27,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
     }
 
     "it should show a nested list difference" in {
-      val output = DiffResultSet(List(Identical("a"), DiffResultSet(List(Identical("b"))))).show()
+      val output = DiffResultSet(List(IdenticalValue("a"), DiffResultSet(List(IdenticalValue("b"))))).show()
       output shouldBe
         s"""Set(
            |     a,
@@ -36,14 +36,14 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
     }
 
     "it should show null" in {
-      val output = DiffResultSet(List(Identical(null), DiffResultValue(null, null))).show()
+      val output = DiffResultSet(List(IdenticalValue(null), DiffResultValue(null, null))).show()
       output shouldBe
         s"""Set(
           |     null,
           |     null -> null)""".stripMargin
     }
     "it shouldn't render identical elements" in {
-      val output = DiffResultSet(List(Identical("a"), DiffResultValue("1", "2"))).show(renderIdentical = false)
+      val output = DiffResultSet(List(IdenticalValue("a"), DiffResultValue("1", "2"))).show(renderIdentical = false)
       output shouldBe
         s"""Set(
            |     1 -> 2)""".stripMargin
@@ -53,7 +53,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
   "diff map output" - {
     "it should show a simple diff" in {
       val output =
-        DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3)))
+        DiffResultMap(Map(IdenticalValue("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3)))
           .show()
       output shouldBe
         s"""Map(
@@ -63,7 +63,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
 
     "it should show an indented diff" in {
       val output =
-        DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3)))
+        DiffResultMap(Map(IdenticalValue("a") -> DiffResultValue(1, 2), DiffResultMissing("b") -> DiffResultMissing(3)))
           .show()
       output shouldBe
         s"""Map(
@@ -73,7 +73,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
 
     "it should show a nested diff" in {
       val output =
-        DiffResultMap(Map(Identical("a") -> DiffResultMap(Map(Identical("b") -> DiffResultValue(1, 2)))))
+        DiffResultMap(Map(IdenticalValue("a") -> DiffResultMap(Map(IdenticalValue("b") -> DiffResultValue(1, 2)))))
           .show()
       output shouldBe
         s"""Map(
@@ -85,9 +85,9 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
       val output =
         DiffResultMap(
           Map(
-            Identical("a") -> DiffResultValue(1, 2),
-            DiffResultValue("b", "c") -> Identical(3),
-            Identical("d") -> Identical(4)
+            IdenticalValue("a") -> DiffResultValue(1, 2),
+            DiffResultValue("b", "c") -> IdenticalValue(3),
+            IdenticalValue("d") -> IdenticalValue(4)
           )
         )
           .show(renderIdentical = false)
@@ -105,7 +105,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
 
       val output = DiffResultObject(
         "List",
-        Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234), "2" -> Identical(1234))
+        Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234), "2" -> IdenticalValue(1234))
       )
         .show()(colorConfigWithPlusMinus)
       output shouldBe
@@ -118,7 +118,7 @@ class DiffResultTest extends AnyFreeSpec with Matchers with DiffxConsoleSupport 
     "it should not render identical fields" in {
       val output = DiffResultObject(
         "List",
-        Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234), "2" -> Identical(1234))
+        Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234), "2" -> IdenticalValue(1234))
       )
         .show(renderIdentical = false)
       output shouldBe

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.diffx.test
 
 import com.softwaremill.diffx.test.ACoproduct.ProductA
-import com.softwaremill.diffx.{Derived, Diff, Identical}
+import com.softwaremill.diffx.{Derived, Diff, IdenticalValue}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -41,7 +41,7 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
   "should work for coproducts" in {
     implicit val dACoproduct: Derived[Diff[ACoproduct]] = Diff.derived[ACoproduct]
 
-    Diff.compare[ACoproduct](ProductA("1"), ProductA("1")) shouldBe Identical(
+    Diff.compare[ACoproduct](ProductA("1"), ProductA("1")) shouldBe IdenticalValue(
       ProductA("1")
     )
   }
@@ -49,7 +49,7 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
   "should allow ignoring on derived diffs" in {
     implicit val dACoproduct: Derived[Diff[ProductA]] = Diff.derived[ProductA].ignore(_.id)
 
-    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe Identical(
+    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe IdenticalValue(
       ProductA("1")
     )
   }
@@ -57,7 +57,7 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
   "should allow modifying derived diffs" in {
     implicit val dACoproduct: Derived[Diff[ProductA]] = Diff.derived[ProductA].modify(_.id).ignore()
 
-    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe Identical(
+    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe IdenticalValue(
       ProductA("1")
     )
   }

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffSemiautoTest.scala
@@ -41,25 +41,19 @@ class DiffSemiautoTest extends AnyFreeSpec with Matchers {
   "should work for coproducts" in {
     implicit val dACoproduct: Derived[Diff[ACoproduct]] = Diff.derived[ACoproduct]
 
-    Diff.compare[ACoproduct](ProductA("1"), ProductA("1")) shouldBe IdenticalValue(
-      ProductA("1")
-    )
+    Diff.compare[ACoproduct](ProductA("1"), ProductA("1")).isIdentical shouldBe true
   }
 
   "should allow ignoring on derived diffs" in {
     implicit val dACoproduct: Derived[Diff[ProductA]] = Diff.derived[ProductA].ignore(_.id)
 
-    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe IdenticalValue(
-      ProductA("1")
-    )
+    Diff.compare[ProductA](ProductA("1"), ProductA("2")).isIdentical shouldBe true
   }
 
   "should allow modifying derived diffs" in {
     implicit val dACoproduct: Derived[Diff[ProductA]] = Diff.derived[ProductA].modify(_.id).ignore()
 
-    Diff.compare[ProductA](ProductA("1"), ProductA("2")) shouldBe IdenticalValue(
-      ProductA("1")
-    )
+    Diff.compare[ProductA](ProductA("1"), ProductA("2")).isIdentical shouldBe true
   }
 }
 

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
@@ -761,7 +761,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
   "tuples" - {
     "tuple2" - {
       "equal tuples should be identical" in {
-        compare((1, 2), (1, 2)) shouldBe IdenticalValue((1, 2))
+        compare((1, 2), (1, 2)).isIdentical shouldBe true
       }
       "different first element should make them different" in {
         compare((1, 2), (3, 2)) shouldBe DiffResultObject(
@@ -778,7 +778,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
     }
     "tuple3" - {
       "equal tuples should be identical" in {
-        compare((1, 2, 3), (1, 2, 3)) shouldBe IdenticalValue((1, 2, 3))
+        compare((1, 2, 3), (1, 2, 3)).isIdentical shouldBe true
       }
       "different first element should make them different" in {
         compare((1, 2, 3), (4, 2, 3)) shouldBe DiffResultObject(

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffTest.scala
@@ -19,14 +19,14 @@ class DiffTest extends AnyFreeSpec with Matchers {
       compare(1, 2) shouldBe DiffResultValue(1, 2)
     }
     "identity" in {
-      compare(1, 1) shouldBe Identical(1)
+      compare(1, 1) shouldBe IdenticalValue(1)
     }
     "contravariant" in {
-      compare(Some(1), Option(1)) shouldBe Identical(1)
+      compare(Some(1), Option(1)) shouldBe IdenticalValue(1)
     }
     "approximate - identical" in {
       val diff = Diff.approximate[Double](0.05)
-      diff(0.12, 0.14) shouldBe Identical(0.12)
+      diff(0.12, 0.14) shouldBe IdenticalValue(0.12)
     }
     "approximate - different" in {
       val diff = Diff.approximate[Double](0.05)
@@ -42,7 +42,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
 
   "products" - {
     "identity" in {
-      compare(p1, p1) shouldBe Identical(p1)
+      compare(p1, p1).isIdentical shouldBe true
     }
 
     "nullable" in {
@@ -55,7 +55,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
         Map(
           "name" -> DiffResultString(List(DiffResultValue(p1.name, p2.name))),
           "age" -> DiffResultValue(p1.age, p2.age),
-          "in" -> Identical(instant)
+          "in" -> IdenticalValue(instant)
         )
       )
     }
@@ -66,13 +66,25 @@ class DiffTest extends AnyFreeSpec with Matchers {
         Map(
           "name" -> DiffResultValue(null, p2.name),
           "age" -> DiffResultValue(p1.age, p2.age),
-          "in" -> Identical(instant)
+          "in" -> IdenticalValue(instant)
         )
       )
     }
 
     "two nulls should be equal" in {
-      compare(p1.copy(name = null), p1.copy(name = null)) shouldBe an[Identical[_]]
+      compare(p1.copy(name = null), p1.copy(name = null)).isIdentical shouldBe true
+    }
+
+    "ignored fields should be different than identical" in {
+      implicit val d: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("name")(Diff.ignored)
+      compare(p1, p1.copy(name = "other")) shouldBe DiffResultObject(
+        "Person",
+        Map(
+          "name" -> DiffResult.Ignored,
+          "age" -> IdenticalValue(p1.age),
+          "in" -> IdenticalValue(p1.in)
+        )
+      )
     }
 
     "ignoring given fields" in {
@@ -95,13 +107,20 @@ class DiffTest extends AnyFreeSpec with Matchers {
       compare(f1, f2) shouldBe DiffResultObject(
         "Family",
         Map(
-          "first" -> Identical(p1),
+          "first" -> DiffResultObject(
+            "Person",
+            Map(
+              "name" -> IdenticalValue(p1.name),
+              "age" -> IdenticalValue(p1.age),
+              "in" -> IdenticalValue(p1.in)
+            )
+          ),
           "second" -> DiffResultObject(
             "Person",
             Map(
               "name" -> DiffResultString(List(DiffResultValue(p2.name, p1.name))),
               "age" -> DiffResultValue(p2.age, p1.age),
-              "in" -> Identical(instant)
+              "in" -> IdenticalValue(instant)
             )
           )
         )
@@ -111,17 +130,24 @@ class DiffTest extends AnyFreeSpec with Matchers {
     "nested products ignoring nested fields" in {
       val f1 = Family(p1, p2)
       val f2 = Family(p1, p1)
-      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second", "name")(Diff.identical)
+      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second", "name")(Diff.ignored)
       compare(f1, f2) shouldBe DiffResultObject(
         "Family",
         Map(
-          "first" -> Identical(p1),
+          "first" -> DiffResultObject(
+            "Person",
+            Map(
+              "name" -> IdenticalValue(p1.name),
+              "age" -> IdenticalValue(p1.age),
+              "in" -> IdenticalValue(p1.in)
+            )
+          ),
           "second" -> DiffResultObject(
             "Person",
             Map(
-              "name" -> Identical(p2.name),
+              "name" -> DiffResult.Ignored,
               "age" -> DiffResultValue(p2.age, p1.age),
-              "in" -> Identical(instant)
+              "in" -> IdenticalValue(instant)
             )
           )
         )
@@ -132,7 +158,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
       val p1p = p1.copy(name = "other")
       val f1 = Family(p1, p2)
       val f2 = Family(p1p, p2.copy(name = "other"))
-      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second", "name")(Diff.identical)
+      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second", "name")(Diff.ignored)
       compare(f1, f2) shouldBe DiffResultObject(
         "Family",
         Map(
@@ -140,11 +166,18 @@ class DiffTest extends AnyFreeSpec with Matchers {
             "Person",
             Map(
               "name" -> DiffResultString(List(DiffResultValue(p1.name, p1p.name))),
-              "age" -> Identical(p1.age),
-              "in" -> Identical(instant)
+              "age" -> IdenticalValue(p1.age),
+              "in" -> IdenticalValue(instant)
             )
           ),
-          "second" -> Identical(p2)
+          "second" -> DiffResultObject(
+            "Person",
+            Map(
+              "name" -> DiffResult.Ignored,
+              "age" -> IdenticalValue(p2.age),
+              "in" -> IdenticalValue(p2.in)
+            )
+          )
         )
       )
     }
@@ -152,8 +185,8 @@ class DiffTest extends AnyFreeSpec with Matchers {
     "nested products ignoring nested products" in {
       val f1 = Family(p1, p2)
       val f2 = Family(p1, p1)
-      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second")(Diff.identical)
-      compare(f1, f2) shouldBe Identical(f1)
+      implicit val d: Diff[Family] = Derived[Diff[Family]].modifyUnsafe("second")(Diff.ignored)
+      compare(f1, f2).isIdentical shouldBe true
     }
 
     "list of products" in {
@@ -165,16 +198,54 @@ class DiffTest extends AnyFreeSpec with Matchers {
           "people" -> DiffResultObject(
             "List",
             Map(
-              "0" -> Identical(p1),
+              "0" -> DiffResultObject(
+                "Person",
+                Map(
+                  "name" -> IdenticalValue(p1.name),
+                  "age" -> IdenticalValue(p1.age),
+                  "in" -> IdenticalValue(p1.in)
+                )
+              ),
               "1" -> DiffResultObject(
                 "Person",
                 Map(
                   "name" -> DiffResultString(List(DiffResultValue(p2.name, p1.name))),
                   "age" -> DiffResultValue(p2.age, p1.age),
-                  "in" -> Identical(instant)
+                  "in" -> IdenticalValue(instant)
                 )
               ),
               "2" -> DiffResultMissing(Person(p1.name, p1.age, instant))
+            )
+          )
+        )
+      )
+    }
+
+    "identical list of products" in {
+      val o1 = Organization(List(p1, p2))
+      val o2 = Organization(List(p1, p2))
+      compare(o1, o2) shouldBe DiffResultObject(
+        "Organization",
+        Map(
+          "people" -> DiffResultObject(
+            "List",
+            Map(
+              "0" -> DiffResultObject(
+                "Person",
+                Map(
+                  "name" -> IdenticalValue(p1.name),
+                  "age" -> IdenticalValue(p1.age),
+                  "in" -> IdenticalValue(p1.in)
+                )
+              ),
+              "1" -> DiffResultObject(
+                "Person",
+                Map(
+                  "name" -> IdenticalValue(p2.name),
+                  "age" -> IdenticalValue(p2.age),
+                  "in" -> IdenticalValue(p2.in)
+                )
+              )
             )
           )
         )
@@ -196,7 +267,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
 
     "sealed trait objects" - {
       "identity" in {
-        compare[TsDirection](TsDirection.Outgoing, TsDirection.Outgoing) shouldBe an[Identical[_]]
+        compare[TsDirection](TsDirection.Outgoing, TsDirection.Outgoing).isIdentical shouldBe true
       }
       "diff" in {
         compare[TsDirection](TsDirection.Outgoing, TsDirection.Incoming) shouldBe DiffResultValue(
@@ -207,7 +278,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
     }
 
     "identity" in {
-      compare(left, left) shouldBe an[Identical[_]]
+      compare(left, left).isIdentical shouldBe true
     }
 
     "nullable" in {
@@ -218,7 +289,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
       compare(left, right) shouldBe DiffResultObject(
         "Foo",
         Map(
-          "bar" -> DiffResultObject("Bar", Map("s" -> Identical("asdf"), "i" -> DiffResultValue(66, 5))),
+          "bar" -> DiffResultObject("Bar", Map("s" -> IdenticalValue("asdf"), "i" -> DiffResultValue(66, 5))),
           "b" -> DiffResultObject("List", Map("0" -> DiffResultValue(1234, 123), "1" -> DiffResultMissing(1234))),
           "parent" -> DiffResultValue("com.softwaremill.diffx.test.Foo", "com.softwaremill.diffx.test.Bar")
         )
@@ -244,7 +315,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
   "collections" - {
     "list" - {
       "identical" in {
-        compare(List("a"), List("a")) shouldBe Identical(List("a"))
+        compare(List("a"), List("a")) shouldBe DiffResultObject("List", Map("0" -> IdenticalValue("a")))
       }
 
       "nullable" in {
@@ -261,20 +332,27 @@ class DiffTest extends AnyFreeSpec with Matchers {
       "use ignored fields from elements" in {
         val o1 = Organization(List(p1, p2))
         val o2 = Organization(List(p1, p1, p1))
-        implicit val d: Diff[Organization] = Derived[Diff[Organization]].modifyUnsafe("people", "name")(Diff.identical)
+        implicit val d: Diff[Organization] = Derived[Diff[Organization]].modifyUnsafe("people", "name")(Diff.ignored)
         compare(o1, o2) shouldBe DiffResultObject(
           "Organization",
           Map(
             "people" -> DiffResultObject(
               "List",
               Map(
-                "0" -> Identical(p1),
+                "0" -> DiffResultObject(
+                  "Person",
+                  Map(
+                    "name" -> DiffResult.Ignored,
+                    "age" -> IdenticalValue(p1.age),
+                    "in" -> IdenticalValue(p1.in)
+                  )
+                ),
                 "1" -> DiffResultObject(
                   "Person",
                   Map(
-                    "name" -> Identical(p2.name),
+                    "name" -> DiffResult.Ignored,
                     "age" -> DiffResultValue(p2.age, p1.age),
-                    "in" -> Identical(instant)
+                    "in" -> IdenticalValue(instant)
                   )
                 ),
                 "2" -> DiffResultMissing(Person(p1.name, p1.age, instant))
@@ -289,14 +367,14 @@ class DiffTest extends AnyFreeSpec with Matchers {
         val o2 = Organization(List(p2, p1))
         implicit val om: ObjectMatcher[Person] = ObjectMatcher.by(_.name)
         implicit val dd: Diff[List[Person]] = Diff[Set[Person]].contramap(_.toSet)
-        compare(o1, o2) shouldBe Identical(Organization(List(p1, p2)))
+        compare(o1, o2).isIdentical shouldBe true
       }
 
       "compare lists using object matcher comparator" in {
         val o1 = Organization(List(p1, p2))
         val o2 = Organization(List(p2, p1))
         implicit val om: ObjectMatcher[(Int, Person)] = ObjectMatcher.byValue(_.name)
-        compare(o1, o2) shouldBe Identical(Organization(List(p1, p2)))
+        compare(o1, o2).isIdentical shouldBe true
       }
 
       "compare lists using explicit object matcher comparator" in {
@@ -305,7 +383,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
         implicit val orgDiff: Diff[Organization] = Derived[Diff[Organization]].modifyMatcherUnsafe("people")(
           ObjectMatcher.byValue[Int, Person](ObjectMatcher.by(_.name))
         )
-        compare(o1, o2) shouldBe Identical(Organization(List(p1, p2)))
+        compare(o1, o2).isIdentical shouldBe true
       }
 
       "should preserve order of elements" in {
@@ -314,11 +392,11 @@ class DiffTest extends AnyFreeSpec with Matchers {
         compare(l1, l2) shouldBe DiffResultObject(
           "List",
           ListMap(
-            "0" -> Identical(1),
-            "1" -> Identical(2),
-            "2" -> Identical(3),
-            "3" -> Identical(4),
-            "4" -> Identical(5),
+            "0" -> IdenticalValue(1),
+            "1" -> IdenticalValue(2),
+            "2" -> IdenticalValue(3),
+            "3" -> IdenticalValue(4),
+            "4" -> IdenticalValue(5),
             "5" -> DiffResultValue(6, 7)
           )
         )
@@ -330,8 +408,8 @@ class DiffTest extends AnyFreeSpec with Matchers {
         compare(l1, l2) shouldBe DiffResultObject(
           "List",
           ListMap(
-            "0" -> Identical(1),
-            "1" -> Identical(2),
+            "0" -> IdenticalValue(1),
+            "1" -> IdenticalValue(2),
             "2" -> DiffResultValue(3, 4),
             "3" -> DiffResultValue(4, 5),
             "4" -> DiffResultValue(5, 6),
@@ -342,7 +420,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
     }
     "sets" - {
       "identity" in {
-        compare(Set(1), Set(1)) shouldBe an[Identical[_]]
+        compare(Set(1), Set(1)).isIdentical shouldBe true
       }
 
       "nullable" in {
@@ -353,24 +431,31 @@ class DiffTest extends AnyFreeSpec with Matchers {
         val diffResult = compare(Set(1, 2, 3, 4, 5), Set(1, 2, 3, 4)).asInstanceOf[DiffResultSet]
         diffResult.diffs should contain theSameElementsAs List(
           DiffResultAdditional(5),
-          Identical(4),
-          Identical(3),
-          Identical(2),
-          Identical(1)
+          IdenticalValue(4),
+          IdenticalValue(3),
+          IdenticalValue(2),
+          IdenticalValue(1)
         )
       }
       "ignored fields from elements" in {
         val p2m = p2.copy(age = 33, in = Instant.now())
-        implicit val d: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.identical)
+        implicit val d: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.ignored)
         implicit val im: ObjectMatcher[Person] = ObjectMatcher.by(_.name)
         compare(Set(p1, p2), Set(p1, p2m)) shouldBe DiffResultSet(
           List(
-            Identical(p1),
             DiffResultObject(
               "Person",
               Map(
-                "name" -> Identical(p2.name),
-                "age" -> Identical(p2.age),
+                "name" -> IdenticalValue(p1.name),
+                "age" -> DiffResult.Ignored,
+                "in" -> IdenticalValue(p1.in)
+              )
+            ),
+            DiffResultObject(
+              "Person",
+              Map(
+                "name" -> IdenticalValue(p2.name),
+                "age" -> DiffResult.Ignored,
                 "in" -> DiffResultValue(p1.in, p2m.in)
               )
             )
@@ -383,33 +468,40 @@ class DiffTest extends AnyFreeSpec with Matchers {
         val diffResult = compare(mSet(1, 2, 3, 4, 5), mSet(1, 2, 3, 4)).asInstanceOf[DiffResultSet]
         diffResult.diffs should contain theSameElementsAs List(
           DiffResultAdditional(5),
-          Identical(4),
-          Identical(3),
-          Identical(2),
-          Identical(1)
+          IdenticalValue(4),
+          IdenticalValue(3),
+          IdenticalValue(2),
+          IdenticalValue(1)
         )
       }
 
       "identical when products are identical using ignored" in {
         val p2m = p2.copy(age = 33, in = Instant.now())
         implicit val d: Diff[Person] = Derived[Diff[Person]]
-          .modifyUnsafe("age")(Diff.identical)
-          .modifyUnsafe("in")(Diff.identical)
-        compare(Set(p1, p2), Set(p1, p2m)) shouldBe Identical(Set(p1, p2))
+          .modifyUnsafe("age")(Diff.ignored)
+          .modifyUnsafe("in")(Diff.ignored)
+        compare(Set(p1, p2), Set(p1, p2m)).isIdentical shouldBe true
       }
 
       "propagate ignore fields to elements" in {
         val p2m = p2.copy(in = Instant.now())
         implicit val im: ObjectMatcher[Person] = ObjectMatcher.by(_.name)
-        implicit val ds: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.identical)
+        implicit val ds: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.ignored)
         compare(Set(p1, p2), Set(p1, p2m)) shouldBe DiffResultSet(
           List(
-            Identical(p1),
             DiffResultObject(
               "Person",
               Map(
-                "name" -> Identical(p2.name),
-                "age" -> Identical(p2.age),
+                "name" -> IdenticalValue(p1.name),
+                "age" -> DiffResult.Ignored,
+                "in" -> IdenticalValue(p1.in)
+              )
+            ),
+            DiffResultObject(
+              "Person",
+              Map(
+                "name" -> IdenticalValue(p2.name),
+                "age" -> DiffResult.Ignored,
                 "in" -> DiffResultValue(p1.in, p2m.in)
               )
             )
@@ -419,14 +511,25 @@ class DiffTest extends AnyFreeSpec with Matchers {
       "set of products" in {
         val p2m = p2.copy(age = 33)
         compare(Set(p1, p2), Set(p1, p2m)) shouldBe DiffResultSet(
-          List(DiffResultAdditional(p2), DiffResultMissing(p2m), Identical(p1))
+          List(
+            DiffResultAdditional(p2),
+            DiffResultMissing(p2m),
+            DiffResultObject(
+              "Person",
+              Map(
+                "name" -> IdenticalValue(p1.name),
+                "age" -> IdenticalValue(p1.age),
+                "in" -> IdenticalValue(p1.in)
+              )
+            )
+          )
         )
       }
       "override set instance" in {
         val p2m = p2.copy(age = 33)
         implicit def setDiff[T, C[W] <: scala.collection.Set[W]]: Diff[C[T]] =
-          (left: C[T], _: C[T], _: DiffContext) => Identical(left)
-        compare(Set(p1, p2), Set(p1, p2m)) shouldBe an[Identical[_]]
+          (left: C[T], _: C[T], _: DiffContext) => IdenticalValue(left)
+        compare(Set(p1, p2), Set(p1, p2m)).isIdentical shouldBe true
       }
 
       "set of products using instance matcher" in {
@@ -437,10 +540,21 @@ class DiffTest extends AnyFreeSpec with Matchers {
           Map(
             "workers" -> DiffResultSet(
               List(
-                Identical(p1),
                 DiffResultObject(
                   "Person",
-                  Map("name" -> Identical(p2.name), "age" -> DiffResultValue(p2.age, p2m.age), "in" -> Identical(p1.in))
+                  Map(
+                    "name" -> IdenticalValue(p1.name),
+                    "age" -> IdenticalValue(p1.age),
+                    "in" -> IdenticalValue(p1.in)
+                  )
+                ),
+                DiffResultObject(
+                  "Person",
+                  Map(
+                    "name" -> IdenticalValue(p2.name),
+                    "age" -> DiffResultValue(p2.age, p2m.age),
+                    "in" -> IdenticalValue(p1.in)
+                  )
                 )
               )
             )
@@ -451,7 +565,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
     "maps" - {
       "identical" in {
         val m1 = Map("a" -> 1)
-        compare(m1, m1) shouldBe an[Identical[_]]
+        compare(m1, m1).isIdentical shouldBe true
       }
 
       "nullable" in {
@@ -461,25 +575,25 @@ class DiffTest extends AnyFreeSpec with Matchers {
       "simple diff" in {
         val m1 = Map("a" -> 1)
         val m2 = Map("a" -> 2)
-        compare(m1, m2) shouldBe DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2)))
+        compare(m1, m2) shouldBe DiffResultMap(Map(IdenticalValue("a") -> DiffResultValue(1, 2)))
       }
 
       "simple diff - mutable map" in {
         val m1 = scala.collection.Map("a" -> 1)
         val m2 = scala.collection.Map("a" -> 2)
-        compare(m1, m2) shouldBe DiffResultMap(Map(Identical("a") -> DiffResultValue(1, 2)))
+        compare(m1, m2) shouldBe DiffResultMap(Map(IdenticalValue("a") -> DiffResultValue(1, 2)))
       }
 
       "propagate ignored fields to elements" in {
-        implicit val dm: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.identical)
+        implicit val dm: Diff[Person] = Derived[Diff[Person]].modifyUnsafe("age")(Diff.ignored)
         compare(Map("first" -> p1), Map("first" -> p2)) shouldBe DiffResultMap(
           Map(
-            Identical("first") -> DiffResultObject(
+            IdenticalValue("first") -> DiffResultObject(
               "Person",
               Map(
                 "name" -> DiffResultString(List(DiffResultValue(p1.name, p2.name))),
-                "age" -> Identical(p1.age),
-                "in" -> Identical(p1.in)
+                "age" -> DiffResult.Ignored,
+                "in" -> IdenticalValue(p1.in)
               )
             )
           )
@@ -489,9 +603,9 @@ class DiffTest extends AnyFreeSpec with Matchers {
       "identical when products are identical using ignore" in {
         implicit val dm: Diff[Person] =
           Derived[Diff[Person]]
-            .modifyUnsafe("age")(Diff.identical)
-            .modifyUnsafe("name")(Diff.identical)
-        compare(Map("first" -> p1), Map("first" -> p2)) shouldBe Identical(Map("first" -> p1))
+            .modifyUnsafe("age")(Diff.ignored)
+            .modifyUnsafe("name")(Diff.ignored)
+        compare(Map("first" -> p1), Map("first" -> p2)).isIdentical shouldBe true
       }
 
       "maps by values" in {
@@ -502,7 +616,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
         compare(
           Map[String, Person]("i1" -> person),
           Map[String, Person]("i2" -> person)
-        ) shouldBe Identical(List(person))
+        ).isIdentical shouldBe true
       }
 
       "ignore part of map's key using keys's diff specification" in {
@@ -510,7 +624,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
 
         val a1 = MyLookup(Map(KeyModel(UUID.randomUUID(), "k1") -> "val1"))
         val a2 = MyLookup(Map(KeyModel(UUID.randomUUID(), "k1") -> "val1"))
-        compare(a1, a2) shouldBe Identical(a1)
+        compare(a1, a2).isIdentical shouldBe true
       }
 
       "match keys using object mapper" in {
@@ -528,9 +642,9 @@ class DiffTest extends AnyFreeSpec with Matchers {
                   "KeyModel",
                   Map(
                     "id" -> DiffResultValue(uuid1, uuid2),
-                    "name" -> Identical("k1")
+                    "name" -> IdenticalValue("k1")
                   )
-                ) -> Identical("val1")
+                ) -> IdenticalValue("val1")
               )
             )
           )
@@ -552,9 +666,9 @@ class DiffTest extends AnyFreeSpec with Matchers {
                   "KeyModel",
                   Map(
                     "id" -> DiffResultValue(uuid1, uuid2),
-                    "name" -> Identical("k1")
+                    "name" -> IdenticalValue("k1")
                   )
-                ) -> Identical("val1")
+                ) -> IdenticalValue("val1")
               )
             )
           )
@@ -565,7 +679,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
       "identical" in {
         val r1 = 0 until 100
         val r2 = 0 until 100
-        compare(r1, r2) shouldBe Identical(r1)
+        compare(r1, r2) shouldBe IdenticalValue(r1)
       }
       "dif" in {
         val r1 = 0 until 100
@@ -587,7 +701,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
       val not = new HasCustomEquals("not")
       val diffInstance = Diff.useEquals[HasCustomEquals]
 
-      diffInstance.apply(a, z) shouldBe Identical(a)
+      diffInstance.apply(a, z) shouldBe IdenticalValue(a)
       diffInstance.apply(a, not) shouldBe DiffResultValue(a, not)
     }
   }
@@ -597,7 +711,7 @@ class DiffTest extends AnyFreeSpec with Matchers {
       val left = "scalaIsAwesome"
       val right = "scalaIsAwesome"
 
-      compare(left, right) shouldBe Identical(left)
+      compare(left, right) shouldBe IdenticalValue(left)
     }
 
     "different strings should be different" in {
@@ -620,9 +734,9 @@ class DiffTest extends AnyFreeSpec with Matchers {
 
       compare(left, right) shouldBe DiffResultString(
         List(
-          Identical("first"),
+          IdenticalValue("first"),
           DiffResultValue("second", "sec???"),
-          Identical("third"),
+          IdenticalValue("third"),
           DiffResultAdditional("fourth")
         )
       )
@@ -631,12 +745,12 @@ class DiffTest extends AnyFreeSpec with Matchers {
   "either" - {
     "equal rights should be identical" in {
       val e1: Either[String, String] = Right("a")
-      compare(e1, e1) shouldBe Identical("a")
+      compare(e1, e1) shouldBe IdenticalValue("a")
 
     }
     "equal lefts should be identical" in {
       val e1: Either[String, String] = Left("a")
-      compare(e1, e1) shouldBe Identical("a")
+      compare(e1, e1) shouldBe IdenticalValue("a")
     }
     "left and right should be different" in {
       val e1: Either[String, String] = Left("a")
@@ -647,41 +761,41 @@ class DiffTest extends AnyFreeSpec with Matchers {
   "tuples" - {
     "tuple2" - {
       "equal tuples should be identical" in {
-        compare((1, 2), (1, 2)) shouldBe Identical((1, 2))
+        compare((1, 2), (1, 2)) shouldBe IdenticalValue((1, 2))
       }
       "different first element should make them different" in {
         compare((1, 2), (3, 2)) shouldBe DiffResultObject(
           "Tuple2",
-          Map("_1" -> DiffResultValue(1, 3), "_2" -> Identical(2))
+          Map("_1" -> DiffResultValue(1, 3), "_2" -> IdenticalValue(2))
         )
       }
       "different second element should make them different" in {
         compare((1, 3), (1, 2)) shouldBe DiffResultObject(
           "Tuple2",
-          Map("_1" -> Identical(1), "_2" -> DiffResultValue(3, 2))
+          Map("_1" -> IdenticalValue(1), "_2" -> DiffResultValue(3, 2))
         )
       }
     }
     "tuple3" - {
       "equal tuples should be identical" in {
-        compare((1, 2, 3), (1, 2, 3)) shouldBe Identical((1, 2, 3))
+        compare((1, 2, 3), (1, 2, 3)) shouldBe IdenticalValue((1, 2, 3))
       }
       "different first element should make them different" in {
         compare((1, 2, 3), (4, 2, 3)) shouldBe DiffResultObject(
           "Tuple3",
-          Map("_1" -> DiffResultValue(1, 4), "_2" -> Identical(2), "_3" -> Identical(3))
+          Map("_1" -> DiffResultValue(1, 4), "_2" -> IdenticalValue(2), "_3" -> IdenticalValue(3))
         )
       }
       "different second element should make them different" in {
         compare((1, 2, 3), (1, 4, 3)) shouldBe DiffResultObject(
           "Tuple3",
-          Map("_1" -> Identical(1), "_2" -> DiffResultValue(2, 4), "_3" -> Identical(3))
+          Map("_1" -> IdenticalValue(1), "_2" -> DiffResultValue(2, 4), "_3" -> IdenticalValue(3))
         )
       }
       "different third element should make them different" in {
         compare((1, 2, 3), (1, 2, 4)) shouldBe DiffResultObject(
           "Tuple3",
-          Map("_1" -> Identical(1), "_2" -> Identical(2), "_3" -> DiffResultValue(3, 4))
+          Map("_1" -> IdenticalValue(1), "_2" -> IdenticalValue(2), "_3" -> DiffResultValue(3, 4))
         )
       }
     }

--- a/munit/src/main/scala/com/softwaremill/diffx/munit/DiffxAssertions.scala
+++ b/munit/src/main/scala/com/softwaremill/diffx/munit/DiffxAssertions.scala
@@ -1,15 +1,14 @@
 package com.softwaremill.diffx.munit
 
-import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff}
 import munit.Assertions._
 import munit.Location
 
 trait DiffxAssertions {
   def assertEqual[T: Diff](t1: T, t2: T)(implicit c: ConsoleColorConfig, loc: Location): Unit = {
     val result = Diff.compare(t1, t2)
-    result match {
-      case different: DiffResultDifferent => fail(different.show())(loc)
-      case _                              => // do nothing
+    if (!result.isIdentical) {
+      fail(result.show())(loc)
     }
   }
 }

--- a/refined/src/test/scala/com/softwaremill/diffx/refined/RefinedSupportTest.scala
+++ b/refined/src/test/scala/com/softwaremill/diffx/refined/RefinedSupportTest.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.diffx.refined
 
-import com.softwaremill.diffx.{DiffResultObject, DiffResultString, DiffResultValue, Identical, _}
+import com.softwaremill.diffx.{DiffResultObject, DiffResultString, DiffResultValue, IdenticalValue, _}
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
@@ -14,7 +14,7 @@ class RefinedSupportTest extends AnyFlatSpec with Matchers {
     val testData2 = TestData(1, "bar")
     compare(testData1, testData2) shouldBe DiffResultObject(
       "TestData",
-      Map("posInt" -> Identical(1), "nonEmptyString" -> DiffResultString(List(DiffResultValue("foo", "bar"))))
+      Map("posInt" -> IdenticalValue(1), "nonEmptyString" -> DiffResultString(List(DiffResultValue("foo", "bar"))))
     )
   }
 }

--- a/scalatest/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
+++ b/scalatest/src/main/scala/com/softwaremill/diffx/scalatest/DiffMatcher.scala
@@ -1,15 +1,16 @@
 package com.softwaremill.diffx.scalatest
 
-import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff}
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait DiffMatcher {
   def matchTo[A: Diff](right: A)(implicit c: ConsoleColorConfig): Matcher[A] = { left =>
-    Diff[A].apply(left, right) match {
-      case c: DiffResultDifferent =>
-        val diff = c.show().split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
-        MatchResult(matches = false, s"Matching error:\n$diff", "")
-      case _ => MatchResult(matches = true, "", "")
+    val result = Diff[A].apply(left, right)
+    if (!result.isIdentical) {
+      val diff = result.show().split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
+      MatchResult(matches = false, s"Matching error:\n$diff", "")
+    } else {
+      MatchResult(matches = true, "", "")
     }
   }
 }

--- a/specs2/src/main/scala/com/softwaremill/diffx/specs2/DiffMatcher.scala
+++ b/specs2/src/main/scala/com/softwaremill/diffx/specs2/DiffMatcher.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.diffx.specs2
 
-import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff}
 import org.specs2.matcher.{Expectable, MatchResult, Matcher}
 
 trait DiffMatcher {
@@ -14,11 +14,13 @@ trait DiffMatcher {
           diff.apply(left.value, right).isIdentical
         },
         okMessage = "",
-        koMessage = diff.apply(left.value, right) match {
-          case c: DiffResultDifferent =>
-            c.show()
-          case _ =>
+        koMessage = {
+          val diffResult = diff.apply(left.value, right)
+          if (!diffResult.isIdentical) {
+            diffResult.show()
+          } else {
             ""
+          }
         },
         left
       )

--- a/tagging/src/test/scala/com/softwaremill/diffx/tagging/test/DiffTaggingSupportTest.scala
+++ b/tagging/src/test/scala/com/softwaremill/diffx/tagging/test/DiffTaggingSupportTest.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.diffx.tagging.test
 
-import com.softwaremill.diffx.{Diff, DiffResultObject, DiffResultValue, Identical}
+import com.softwaremill.diffx.{Diff, DiffResultObject, DiffResultValue, IdenticalValue}
 import com.softwaremill.diffx.tagging._
 import com.softwaremill.tagging._
 import com.softwaremill.tagging.@@
@@ -15,7 +15,7 @@ class DiffTaggingSupportTest extends AnyFlatSpec with Matchers {
     val p2 = 1.taggedWith[T2]
     compare(TestData(p1, p2), TestData(p11, p2)) shouldBe DiffResultObject(
       "TestData",
-      Map("p1" -> DiffResultValue(p1, p11), "p2" -> Identical(p2))
+      Map("p1" -> DiffResultValue(p1, p11), "p2" -> IdenticalValue(p2))
     )
   }
 

--- a/utest/src/main/scala/com/softwaremill/diffx/utest/DiffxAssertions.scala
+++ b/utest/src/main/scala/com/softwaremill/diffx/utest/DiffxAssertions.scala
@@ -1,15 +1,14 @@
 package com.softwaremill.diffx.utest
 
-import com.softwaremill.diffx.{ConsoleColorConfig, Diff, DiffResultDifferent}
+import com.softwaremill.diffx.{ConsoleColorConfig, Diff}
 import utest.AssertionError
 
 trait DiffxAssertions {
 
   def assertEqual[T: Diff](t1: T, t2: T)(implicit c: ConsoleColorConfig): Unit = {
     val result = Diff.compare(t1, t2)
-    result match {
-      case different: DiffResultDifferent => throw AssertionError(different.show(), Seq.empty, null)
-      case _                              => // do nothing
+    if (!result.isIdentical) {
+      throw AssertionError(result.show(), Seq.empty, null)
     }
   }
 }


### PR DESCRIPTION
this fixes #262

TLDR:
Instead of merging identical results into the most top-level identical value, we will always have `DiffResult` objects representing results. This way we can still control displaying and correctly display ignored fields.

Whether the end result is identical can be checked same as previously using `.isIdentical` method on `DiffResult` object.

- [ ] Consider ability to skip rendering ignored fields