### PR TITLE
Update typo in scalatest section

### DIFF
--- a/docs-sources/test-frameworks/scalatest.md
+++ b/docs-sources/test-frameworks/scalatest.md
@@ -11,7 +11,7 @@ For use with `should` matchers:
 
 For use with `must` matchers:
 ```scala
-"com.softwaremill.diffx" %% "diffx-scalatest-should" % "@VERSION@" % Test
+"com.softwaremill.diffx" %% "diffx-scalatest-must" % "@VERSION@" % Test
 ```
 
 ## mill


### PR DESCRIPTION
Update typo: scalatest `must` matchers now refers to `diffx-scalatest-must`