### PR TITLE
Update java action to v2

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
       - name: Cache sbt


### PR DESCRIPTION
Since v3 core dumped(https://github.com/softwaremill/diffx/pull/388) let's try v2