### PR TITLE
Fix propagating child modifications throughout the DiffContext

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/DiffContext.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffContext.scala
@@ -67,7 +67,7 @@ object Tree {
   def empty[T]: Node[T] = Tree.Node[T](Map.empty)
 
   case class Leaf[T](v: T) extends Tree[T] {
-    override def merge(tree: Tree[T]): Tree[T] = this
+    override def merge(tree: Tree[T]): Tree[T] = tree
   }
   case class Node[T](tries: Map[ModifyPath, Tree[T]]) extends Tree[T] {
     override def merge(tree: Tree[T]): Tree[T] = {

--- a/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
+++ b/core/src/test/scala/com/softwaremill/diffx/test/DiffModifyIntegrationTest.scala
@@ -320,4 +320,31 @@ class DiffModifyIntegrationTest extends AnyFlatSpec with Matchers with AutoDeriv
       )
     )
   }
+
+  it should "allow propagate modification from substituted diff instance" in {
+    case class Address(house: Int, street: String)
+    case class Person(name: String, address: Address)
+
+    val add = Diff.summon[Address].ignore(_.house)
+    val d = Diff
+      .summon[Person]
+      .modify(_.address)
+      .setTo(add)
+
+    val a1 = Address(123, "Robin St.")
+    val a2 = Address(456, "Robin St.")
+
+    val p1 = Person("Mason", a1)
+    val p2 = Person("Mason", a2)
+    d(p1, p2) shouldBe DiffResultObject(
+      "Person",
+      ListMap(
+        "name" -> IdenticalValue("Mason"),
+        "address" -> DiffResultObject(
+          "Address",
+          ListMap("house" -> IdenticalValue("<ignored>"), "street" -> IdenticalValue("Robin St."))
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Relates to #418


This is a partial fix, because the design of `DiffContext` and how the modifications are propagated is fundamentally broken. 

For example following case won't work:
```scala
    case class Address(house: Int, street: String)
    case class Person(name: String, address: Address)

    val add = Diff.summon[Address].ignore(_.house)
    val d = Diff
      .summon[Person]
      .modify(_.address)
      .setTo(add)
      .modify(_.address.street).ignore
```

The second modification won't work and there is no good way to fix it.