### PR TITLE
Replace String.repeat with StringLike.* operator

### DIFF
--- a/core/src/main/scala/com/softwaremill/diffx/DiffResultPrinter.scala
+++ b/core/src/main/scala/com/softwaremill/diffx/DiffResultPrinter.scala
@@ -97,6 +97,6 @@ object DiffResultPrinter {
     withColor(l, c.left, indent) + arrowColor(" -> ") + withColor(r, c.right, indent)
 
   private def withColor(value: String, color: String => String, indent: Int): String = {
-    value.split("\n", -1).map(color(_)).mkString("\n" + " ".repeat(indent))
+    value.split("\n", -1).map(color(_)).mkString("\n" + " " * indent)
   }
 }


### PR DESCRIPTION
String.repeat is only available in JVM 11 or newer but StringLike.`*` operator is available since Scala 2.8, regardless of JVM version.